### PR TITLE
0618박지수 | 데일리 문진 응답 관련 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -32,8 +32,8 @@ public class SecurityConfig {
         return http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
-
                         // 인증 필요 없는 URL (loginForm, join, 정적 자원 등)
+                        .requestMatchers("/.well-known/**", "/firebase-messaging-sw.js").permitAll()
                         .requestMatchers(AppURLs.getCombineURL(AppURLs.PUBLIC_URLS, AppURLs.PREFIX_WHITELIST)).permitAll()
                         .requestMatchers(AppURLs.getCombineURL(AppURLs.MEMBER_URLS, AppURLs.MEMBER_URLS_PREFIX)).hasRole("MEMBER")
                         .requestMatchers(AppURLs.getCombineURL(AppURLs.MANAGER_URLS, AppURLs.MANAGER_URLS_PREFIX)).hasRole("MANAGER")

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -33,7 +33,6 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
                         // 인증 필요 없는 URL (loginForm, join, 정적 자원 등)
-                        .requestMatchers("/.well-known/**", "/firebase-messaging-sw.js").permitAll()
                         .requestMatchers(AppURLs.getCombineURL(AppURLs.PUBLIC_URLS, AppURLs.PREFIX_WHITELIST)).permitAll()
                         .requestMatchers(AppURLs.getCombineURL(AppURLs.MEMBER_URLS, AppURLs.MEMBER_URLS_PREFIX)).hasRole("MEMBER")
                         .requestMatchers(AppURLs.getCombineURL(AppURLs.MANAGER_URLS, AppURLs.MANAGER_URLS_PREFIX)).hasRole("MANAGER")

--- a/src/main/java/com/example/demo/controller/MainController.java
+++ b/src/main/java/com/example/demo/controller/MainController.java
@@ -15,11 +15,6 @@ public class MainController {
         return "index";
     }
 
-    @GetMapping("/dailySurvey")
-    public String getDailySurveyPage() {
-        return "dailySurvey";
-    }
-
     @GetMapping("/dailySurvey/result")
     public String getSurveyResultPage() {
         return "dailySurveyResult";

--- a/src/main/java/com/example/demo/survey/controller/DailyAnswerPageController.java
+++ b/src/main/java/com/example/demo/survey/controller/DailyAnswerPageController.java
@@ -1,0 +1,98 @@
+package com.example.demo.survey.controller;
+
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.enums.SurveyCategory;
+import com.example.demo.survey.dto.DailyAnswerDto;
+import com.example.demo.survey.entity.DailyAnswer;
+import com.example.demo.survey.repository.DailyAnswerRepository;
+import com.example.demo.users.entity.Child;
+import com.example.demo.users.entity.Users;
+import com.example.demo.users.exception.UserNotFoundException;
+import com.example.demo.users.service.ChildService;
+import com.example.demo.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.*;
+
+@Controller
+@RequiredArgsConstructor
+public class DailyAnswerPageController {
+
+    private final UserService           userService;
+    private final ChildService          childService;
+    private final DailyAnswerRepository answerRepo;
+
+    /** 뷰: 필터용 드롭다운 데이터만 전달 */
+    @GetMapping("/dailyAnswer")
+    public String showAnswerPage(Authentication auth, Model model) {
+        String principal = auth.getName();
+        Users me;
+        try {
+            me = userService.findByUsernameEntity(principal);
+        } catch (UserNotFoundException e) {
+            me = userService.findByUuidEntity(principal);
+        }
+
+        model.addAttribute("children",
+                childService.findByUsersId(me.getId()));
+        model.addAttribute("categories",
+                Arrays.stream(SurveyCategory.values())
+                        .filter(c -> c != SurveyCategory.ALL && c != SurveyCategory.VARIOUS)
+                        .toList());
+        model.addAttribute("ageGroups",
+                Arrays.stream(AgeGroup.values())
+                        .filter(a -> a != AgeGroup.ALL && a != AgeGroup.VARIOUS)
+                        .toList());
+
+        return "dailyAnswer";
+    }
+
+    /** API: 페이징·필터링된 응답 JSON 반환 */
+    @GetMapping("/api/answers")
+    @ResponseBody
+    public Map<String,Object> getAnswers(
+            @RequestParam(required = false) Long childId,
+            @RequestParam(required = false) SurveyCategory category,
+            @RequestParam(required = false) AgeGroup ageGroup,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        Pageable pageable = PageRequest.of(page, 4);
+        Page<DailyAnswer> paged = answerRepo.findByFilters(childId, category, ageGroup, pageable);
+
+        // content → DTO
+        List<DailyAnswerDto> dtos = paged.map(da -> {
+            // 자녀 display
+            LocalDate bday = da.getChild().getBirthday().toLocalDate();
+            int age = Period.between(bday, LocalDate.now()).getYears();
+            String childDisplay = da.getChild().getName()
+                    + " (" + da.getChild().getNickname() + ") - " + age + "세";
+            return new DailyAnswerDto(
+                    da.getId(),
+                    childDisplay,
+                    da.getCategory().getDisplayName(),
+                    da.getSurvey().getAgeGroup().getDisplayName(),
+                    da.getQuestion(),
+                    da.getAnswer(),
+                    da.getWeight(),
+                    da.getCreatedAt()
+            );
+        }).getContent();
+
+        // 메타데이터 포함
+        Map<String,Object> result = new HashMap<>();
+        result.put("content",       dtos);
+        result.put("currentPage",   paged.getNumber());
+        result.put("totalPages",    paged.getTotalPages());
+        result.put("totalElements", paged.getTotalElements());
+        return result;
+    }
+}

--- a/src/main/java/com/example/demo/survey/controller/DailySurveyAdminController.java
+++ b/src/main/java/com/example/demo/survey/controller/DailySurveyAdminController.java
@@ -14,9 +14,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Controller
-@RequestMapping("/admin/surveys")
+@RequestMapping("/admin/surveys/daily")
 @RequiredArgsConstructor
-public class SurveyAdminController {
+public class DailySurveyAdminController {
 
     private final DailySurveyService dailySurveyService;
     private final List<AgeGroup> ageGroups = Arrays.stream(AgeGroup.values())

--- a/src/main/java/com/example/demo/survey/controller/DailySurveyController.java
+++ b/src/main/java/com/example/demo/survey/controller/DailySurveyController.java
@@ -3,8 +3,14 @@ package com.example.demo.survey.controller;
 import com.example.demo.enums.AgeGroup;
 import com.example.demo.enums.SurveyCategory;
 import com.example.demo.survey.dto.SurveyRequestDto;
+import com.example.demo.survey.entity.DailyAnswer;
 import com.example.demo.survey.entity.DailySurvey;
+import com.example.demo.survey.repository.DailyAnswerRepository;
 import com.example.demo.survey.service.DailySurveyService;
+import com.example.demo.users.entity.Child;
+import com.example.demo.users.entity.Member;
+import com.example.demo.users.repository.MemberRepository;
+import com.example.demo.users.service.ChildService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +25,9 @@ import java.util.Map;
 public class DailySurveyController {
 
     private final DailySurveyService dailySurveyService;
+    private final DailyAnswerRepository answerRepo;
+    private final ChildService childService;
+    private final MemberRepository memberRepository;
 
     @GetMapping("/{ageGroup}")
     @ResponseBody
@@ -26,16 +35,23 @@ public class DailySurveyController {
         return dailySurveyService.getSurveysByAgeGroup(ageGroup);
     }
 
-    @PostMapping(value = "/submit", consumes = "application/json; charset=UTF-8", produces = "application/json; charset=UTF-8")
+    @PostMapping(value = "/submit",
+            consumes = "application/json; charset=UTF-8",
+            produces = "application/json; charset=UTF-8")
     @ResponseBody
-    public Map<String, Object> submitSurvey(@RequestBody SurveyRequestDto dto) {
+    public Map<String,Object> submitSurvey(@RequestBody SurveyRequestDto dto) {
+        // 1) DTO 검증
         System.out.println("====== SurveyRequestDto DTO 확인 ======");
         System.out.println("받은 ageGroup: " + dto.getAgeGroup());
         System.out.println("받은 answers: " + dto.getAnswers());
         System.out.println("===================================");
 
-        List<DailySurvey> surveyList = dailySurveyService.getSurveysByAgeGroup(dto.getAgeGroup());
-        if (surveyList == null || surveyList.isEmpty()) {
+        // 2) 자녀 엔티티 조회
+        Child child = childService.findById(dto.getChildId());
+
+        // 3) 설문 목록 조회
+        List<DailySurvey> surveys = dailySurveyService.getSurveysByAgeGroup(dto.getAgeGroup());
+        if (surveys == null || surveys.isEmpty()) {
             throw new IllegalArgumentException("문진 데이터가 없습니다.");
         }
 
@@ -43,21 +59,49 @@ public class DailySurveyController {
             throw new IllegalArgumentException("답변이 없습니다.");
         }
 
-        if (dto.getAnswers().size() != surveyList.size()) {
+        if (dto.getAnswers().size() != surveys.size()) {
             throw new IllegalArgumentException("응답 배열과 설문 데이터 크기가 일치하지 않습니다.");
         }
+        // 4) 답변 저장
+        for (int i = 0; i < surveys.size(); i++) {
+            DailySurvey s = surveys.get(i);
+            int answerIdx = dto.getAnswers().get(i);
 
-        double riskScore = dailySurveyService.calculateRiskScore(dto.getAnswers(), surveyList);
-        Map<SurveyCategory, Double> categoryScores = dailySurveyService.calculateCategoryRiskScore(dto.getAnswers(), surveyList);
+            String answerText;
+            switch (answerIdx) {
+                case 1: answerText = s.getAnswer1(); break;
+                case 2: answerText = s.getAnswer2(); break;
+                case 3: answerText = s.getAnswer3(); break;
+                case 4: answerText = s.getAnswer4(); break;
+                case 5: answerText = s.getAnswer5(); break;
+                default: answerText = "";
+            }
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("totalRiskScore", riskScore);
-        result.put("categoryScores", categoryScores);
+            DailyAnswer da = new DailyAnswer();
+            da.setChild(child);
+            da.setSurvey(s);
+            da.setCategory(s.getCategory());
+            da.setQuestion(s.getQuestion());
+            da.setAnswer(answerText);
+            da.setWeight(s.getWeight());
+            answerRepo.save(da);
+        }
 
+        // 5) 포인트 적립: 이 child의 부모(Member) totalPoint += 500
+        Member parent = child.getParent();
+        if (parent.getTotalPoint() == null) {
+            parent.setTotalPoint(0);
+        }
+        parent.setTotalPoint(parent.getTotalPoint() + 500);
+        memberRepository.save(parent);
+
+        // 6) 기존 위험도 계산 로직
+        double totalRisk = dailySurveyService.calculateRiskScore(dto.getAnswers(), surveys);
+        Map<String,Object> result = new HashMap<>();
+        result.put("totalRiskScore", totalRisk);
+        result.put("categoryScores", dailySurveyService.calculateCategoryRiskScore(dto.getAnswers(), surveys));
         return result;
     }
-
-
 
     // 결과 페이지 라우팅 추가
     @GetMapping("/result")

--- a/src/main/java/com/example/demo/survey/controller/DailySurveyPageController.java
+++ b/src/main/java/com/example/demo/survey/controller/DailySurveyPageController.java
@@ -1,0 +1,43 @@
+package com.example.demo.survey.controller;
+
+import com.example.demo.users.entity.Child;
+import com.example.demo.users.entity.Users;
+import com.example.demo.users.exception.UserNotFoundException;
+import com.example.demo.users.service.ChildService;
+import com.example.demo.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class DailySurveyPageController {
+
+    private final UserService  userService;
+    private final ChildService childService;
+
+    @GetMapping("/dailySurvey")
+    public String showDailySurveyPage(Authentication authentication, Model model) {
+        String principalName = authentication.getName();
+        Users me;
+
+        // 1) 우선 principalName 이 username(이메일) 일 경우 조회 시도
+        try {
+            me = userService.findByUsernameEntity(principalName);
+        }
+        // 2) 실패(UserNotFoundException) 하면 principalName 을 UUID 로 간주
+        catch (UserNotFoundException e) {
+            me = userService.findByUuidEntity(principalName);
+        }
+
+        // 3) 올바른 사용자의 자녀 목록 조회
+        List<Child> children = childService.findByUsersId(me.getId());
+        model.addAttribute("children", children);
+
+        return "dailySurvey";
+    }
+}

--- a/src/main/java/com/example/demo/survey/controller/SurveyApiController.java
+++ b/src/main/java/com/example/demo/survey/controller/SurveyApiController.java
@@ -18,14 +18,14 @@ import java.util.List;
 public class SurveyApiController {
     private final SurveySetService service;
 
-//    @GetMapping
-//    public List<? extends BaseSurvey> getSurveys(
-//            @RequestParam String type,
-//            @RequestParam(defaultValue = "ALL") AgeGroup age,
-//            @RequestParam(defaultValue = "ALL") SurveyCategory category
-//    ) {
-//        return "SPECIAL".equals(type)
-//                ? service.allSpecial(age, category)
-//                : service.allGroup(age, category);
-//    }
+    @GetMapping
+    public List<? extends BaseSurvey> getSurveys(
+            @RequestParam String type,
+            @RequestParam(defaultValue = "ALL") AgeGroup age,
+            @RequestParam(defaultValue = "ALL") SurveyCategory category
+    ) {
+        return "SPECIAL".equals(type)
+                ? service.allSpecial(age, category)
+                : service.allGroup(age, category);
+    }
 }

--- a/src/main/java/com/example/demo/survey/dto/DailyAnswerDto.java
+++ b/src/main/java/com/example/demo/survey/dto/DailyAnswerDto.java
@@ -1,0 +1,23 @@
+package com.example.demo.survey.dto;
+
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.enums.SurveyCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+public class DailyAnswerDto {
+    private Long           id;
+    private String         childName;
+    private String         category;
+    private String         ageGroup;
+    private String         question;
+    private String         answer;
+    private Integer         weight;
+    private LocalDateTime  createdAt;
+}

--- a/src/main/java/com/example/demo/survey/dto/SurveyRequestDto.java
+++ b/src/main/java/com/example/demo/survey/dto/SurveyRequestDto.java
@@ -11,5 +11,6 @@ import java.util.List;
 @NoArgsConstructor
 public class SurveyRequestDto {
     private AgeGroup ageGroup;
+    private Long childId;
     private List<Integer> answers;
 }

--- a/src/main/java/com/example/demo/survey/entity/DailyAnswer.java
+++ b/src/main/java/com/example/demo/survey/entity/DailyAnswer.java
@@ -1,0 +1,46 @@
+package com.example.demo.survey.entity;
+
+import com.example.demo.entity.BaseEntity;
+import com.example.demo.enums.SurveyCategory;
+import com.example.demo.users.entity.Child;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "daily_answer")
+@Getter
+@Setter
+public class DailyAnswer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "daily_answer_id")
+    private Long id;
+
+    // 데일리 문진 항목 (daily_survey) 과 N:1
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", nullable = false)
+    private DailySurvey survey;
+
+    // 자녀 (child) 과 N:1
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Child child;
+
+    // DailySurvey.category 와 같은 값
+    @Column(nullable = false)
+    private SurveyCategory category;
+
+    @Column(nullable = false)
+    private String question;
+
+    // 실제 사용자가 선택한 답변 텍스트
+    @Column(nullable = false)
+    private String answer;
+
+
+    // 가중치(위험도 도출 시 사용)
+    @Column(nullable = false)
+    private Integer weight;
+}

--- a/src/main/java/com/example/demo/survey/repository/DailyAnswerRepository.java
+++ b/src/main/java/com/example/demo/survey/repository/DailyAnswerRepository.java
@@ -1,0 +1,37 @@
+package com.example.demo.survey.repository;
+
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.enums.SurveyCategory;
+import com.example.demo.survey.entity.DailyAnswer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DailyAnswerRepository extends JpaRepository<DailyAnswer, Long> {
+    /**
+     * childId, category, ageGroup 조건으로 필터링.
+     * 파라미터가 null 이면 해당 조건은 무시합니다.
+     * 페이징은 Pageable 에 의해 처리됩니다.
+     */
+    @Query("""
+      select da
+      from DailyAnswer da
+      join da.survey s
+      where (:childId   is null or da.child.id     = :childId)
+        and (:category  is null or da.category      = :category)
+        and (:ageGroup  is null or s.ageGroup       = :ageGroup)
+      order by da.createdAt desc
+    """)
+    Page<DailyAnswer> findByFilters(
+            Long childId,
+            SurveyCategory category,
+            AgeGroup ageGroup,
+            Pageable pageable
+    );
+
+}

--- a/src/main/java/com/example/demo/users/repository/ChildRepository.java
+++ b/src/main/java/com/example/demo/users/repository/ChildRepository.java
@@ -24,4 +24,9 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
 
     // 특정 부모의 자녀 중 위험군만 조회 (예시)
     List<Child> findByParentAndRiskGroupTrue(Member parent);
+
+    // Member → Child 관계에서, 현재 로그인한 유저의 Member.id 로 조회
+    // child.parent.users.id = ? 인 자녀들을 모두 가져옴
+    List<Child> findByParentUsersId(Long usersId);
+
 }

--- a/src/main/java/com/example/demo/users/service/ChildService.java
+++ b/src/main/java/com/example/demo/users/service/ChildService.java
@@ -7,6 +7,8 @@ import groovy.util.logging.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @Slf4j
 public class ChildService extends BaseService<Child, ChildRepository> {
@@ -29,6 +31,10 @@ public class ChildService extends BaseService<Child, ChildRepository> {
     public Child findById(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 자녀를 찾을 수 없습니다. ID=" + id));
+    }
+
+    public List<Child> findByUsersId(Long usersId) {
+        return repository.findByParentUsersId(usersId);
     }
 
     public Child get(Long childId) {

--- a/src/main/java/com/example/demo/users/service/UserService.java
+++ b/src/main/java/com/example/demo/users/service/UserService.java
@@ -304,7 +304,24 @@ public class UserService {
     }
 
 
+    public Users findByUsername(String username) {
+        Optional<Users> user = userRepository.findByUsername(username);
+        if(user.isPresent()){
+            return user.get();
+        } else{
+            throw new UserNotFoundException("유저가 없어요");
+        }
+    }
 
+    // 1) username(email) 으로 Users 엔티티 조회
+    public Users findByUsernameEntity(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException("유저가 없어요: " + username));
+    }
 
-
+    // 2) uuid 로 Users 엔티티 조회 (이미 DTO용 getMemberByUUID 가 있지만, 엔티티가 필요하면)
+    public Users findByUuidEntity(String uuid) {
+        return userRepository.findByUuid(uuid)
+                .orElseThrow(() -> new UserNotFoundException("유저가 없어요 (uuid): " + uuid));
+    }
 }

--- a/src/main/resources/templates/admin/surveys/dailyForm.html
+++ b/src/main/resources/templates/admin/surveys/dailyForm.html
@@ -15,8 +15,8 @@
         class="text-2xl font-semibold mb-6"></h1>
 
     <form th:action="${survey.id} == null
-                     ? @{/admin/surveys}
-                     : @{/admin/surveys/{id}(id=${survey.id})}"
+                     ? @{/admin/surveys/daily}
+                     : @{/admin/surveys/daily/{id}(id=${survey.id})}"
           method="post" class="space-y-4 max-w-lg">
         <!-- 연령대 -->
         <label class="block">

--- a/src/main/resources/templates/admin/surveys/dailyList.html
+++ b/src/main/resources/templates/admin/surveys/dailyList.html
@@ -11,7 +11,7 @@
 <th:block layout:fragment="content">
     <h1 class="text-2xl font-semibold mb-4">관리자 - 데일리 문진 목록</h1>
 
-    <form th:action="@{/admin/surveys}" method="get" class="flex gap-4 items-center mb-6">
+    <form th:action="@{/admin/surveys/daily}" method="get" class="flex gap-4 items-center mb-6">
         <label class="flex items-center gap-2">
             <span>연령대:</span>
             <select name="ageGroup" class="border p-2 rounded">
@@ -47,7 +47,7 @@
         </button>
     </form>
 
-    <a th:href="@{/admin/surveys/new}"
+    <a th:href="@{/admin/surveys/daily/new}"
        class="inline-block mb-4 text-green-600 hover:underline">
         ➕ 문진 추가
     </a>
@@ -69,9 +69,9 @@
             <td class="border p-2" th:text="${s.question}"></td>
             <td class="border p-2" th:text="${s.weight}"></td>
             <td class="border p-2">
-                <a th:href="@{/admin/surveys/{id}/edit(id=${s.id})}"
+                <a th:href="@{/admin/surveys/daily/{id}/edit(id=${s.id})}"
                    class="text-blue-600 mr-3 hover:underline">수정</a>
-                <form th:action="@{/admin/surveys/{id}/delete(id=${s.id})}"
+                <form th:action="@{/admin/surveys/daily/{id}/delete(id=${s.id})}"
                       method="post" class="inline"
                       onsubmit="return confirm('삭제하시겠습니까?');">
                     <button type="submit" class="text-red-600 hover:underline">

--- a/src/main/resources/templates/dailyAnswer.html
+++ b/src/main/resources/templates/dailyAnswer.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>응답 조회</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<th:block layout:fragment="content">
+    <h1 class="text-2xl font-bold mb-4">문진 응답 조회</h1>
+
+    <!-- 필터 -->
+    <div class="flex space-x-4 mb-4">
+        <!-- 자녀 -->
+        <div>
+            <label class="block mb-1">자녀 선택</label>
+            <select id="childSelect" class="border p-2 rounded">
+                <option value="">전체</option>
+                <option th:each="c : ${children}"
+                        th:value="${c.id}"
+                        th:text="${c.name + ' ('+c.nickname+')'}">
+                </option>
+            </select>
+        </div>
+        <!-- 카테고리 -->
+        <div>
+            <label class="block mb-1">카테고리</label>
+            <select id="categorySelect" class="border p-2 rounded">
+                <option value="">전체</option>
+                <option th:each="cat : ${categories}"
+                        th:value="${cat.name()}"
+                        th:text="${cat.displayName}">
+                </option>
+            </select>
+        </div>
+        <!-- 연령대 -->
+        <div>
+            <label class="block mb-1">연령대</label>
+            <select id="ageGroupSelect" class="border p-2 rounded">
+                <option value="">전체</option>
+                <option th:each="ag : ${ageGroups}"
+                        th:value="${ag.name()}"
+                        th:text="${ag.displayName}">
+                </option>
+            </select>
+        </div>
+        <button onclick="loadAnswers(0)"
+                class="self-end bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">
+            조회
+        </button>
+    </div>
+
+    <!-- 결과 -->
+    <div id="answersContainer" class="space-y-4"></div>
+    <!-- 페이지네이션 -->
+    <div id="pagination" class="flex space-x-2 mt-4"></div>
+
+    <script>
+        function loadAnswers(page = 0) {
+          const childId  = document.getElementById('childSelect').value;
+          const category = document.getElementById('categorySelect').value;
+          const ageGroup = document.getElementById('ageGroupSelect').value;
+
+          const params = new URLSearchParams();
+          if (childId)  params.append('childId',  childId);
+          if (category) params.append('category', category);
+          if (ageGroup) params.append('ageGroup', ageGroup);
+          params.append('page', page);
+
+          fetch('/api/answers?' + params.toString())
+            .then(res => res.json())
+            .then(data => renderAnswers(data))
+            .catch(() => alert('응답 데이터를 불러오는 데 실패했습니다.'));
+        }
+
+        function renderAnswers(data) {
+          const { content, currentPage, totalPages } = data;
+          const container = document.getElementById('answersContainer');
+          container.innerHTML = '';
+          if (content.length === 0) {
+            container.innerHTML = '<p class="text-gray-500">조회된 응답이 없습니다.</p>';
+          } else {
+            content.forEach(a => {
+              const div = document.createElement('div');
+              div.className = 'border p-4 rounded shadow-sm';
+              div.innerHTML = `
+                <p><strong>자녀:</strong> ${a.childName}</p>
+                <p><strong>카테고리:</strong> ${a.category},
+                   <strong>연령대:</strong> ${a.ageGroup}</p>
+                <p><strong>질문:</strong> ${a.question}</p>
+                <p><strong>답변:</strong> ${a.answer} (가중치 ${a.weight})</p>
+                <p class="text-sm text-gray-500">
+                  제출일: ${new Date(a.createdAt).toLocaleString()}
+                </p>
+              `;
+              container.appendChild(div);
+            });
+          }
+          renderPagination(currentPage, totalPages);
+        }
+
+        function renderPagination(currentPage, totalPages) {
+          const pagDiv = document.getElementById('pagination');
+          pagDiv.innerHTML = '';
+
+          // 이전
+          if (currentPage > 0) {
+            const prev = document.createElement('button');
+            prev.textContent = '◀ 이전';
+            prev.onclick = () => loadAnswers(currentPage - 1);
+            pagDiv.appendChild(prev);
+          }
+
+          // 페이지 번호
+          for (let i = 0; i < totalPages; i++) {
+            const btn = document.createElement('button');
+            btn.textContent = i + 1;
+            if (i === currentPage) {
+              btn.disabled = true;
+              btn.className = 'font-bold';
+            } else {
+              btn.onclick = () => loadAnswers(i);
+            }
+            pagDiv.appendChild(btn);
+          }
+
+          // 다음
+          if (currentPage < totalPages - 1) {
+            const next = document.createElement('button');
+            next.textContent = '다음 ▶';
+            next.onclick = () => loadAnswers(currentPage + 1);
+            pagDiv.appendChild(next);
+          }
+        }
+
+        // 초기 호출
+        document.addEventListener('DOMContentLoaded', () => loadAnswers(0));
+    </script>
+</th:block>
+</html>

--- a/src/main/resources/templates/dailySurvey.html
+++ b/src/main/resources/templates/dailySurvey.html
@@ -12,7 +12,16 @@
 
     <h1 class="text-2xl font-bold mb-4">데일리 문진</h1>
 
-    <!-- 연령대 선택 (일반 HTML select 로 변경) -->
+    <label for="childSelect" class="block mb-2 font-semibold">자녀 선택:</label>
+    <select id="childSelect" name="childId" class="border p-2 rounded mb-4">
+        <option value="">-- 자녀를 선택하세요 --</option>
+        <option th:each="c : ${children}"
+                th:value="${c.id}"
+                th:text="${c.name + ' (' + c.nickname + ')'}">
+        </option>
+    </select>
+
+    <!-- 연령대 선택 -->
     <label for="ageGroup" class="block mb-2 font-semibold">연령대 선택:</label>
     <select id="ageGroup" name="ageGroup" class="border p-2 rounded mb-4">
         <option value="">-- 연령대를 선택하세요 --</option>
@@ -85,11 +94,15 @@
             return;
           }
 
+          const childId = document.getElementById("childSelect").value;
+          if (!childId) { alert("자녀를 선택해주세요!"); return; }
+
           fetch("/api/surveys/submit", {
             method: "POST",
             headers: { "Content-Type": "application/json; charset=UTF-8" },
             body: JSON.stringify({
-              ageGroup: ageGroupSelect.value,  // e.g. "AGE_0_12"
+              ageGroup: ageGroupSelect.value,
+              childId:  Number(childId),
               answers: answers
             })
           })

--- a/src/main/resources/templates/dailySurveyResult.html
+++ b/src/main/resources/templates/dailySurveyResult.html
@@ -1,75 +1,53 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/default_layout}">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Charti</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>데일리 문진</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap"
-          rel="stylesheet">
-    <style>
-        body { font-family: 'Poppins', sans-serif; }
-    </style>
 </head>
 <th:block layout:fragment="content">
-<h1 class="text-2xl font-bold mb-4">데일리 문진 결과</h1>
-<div id="result-container" class="mb-4"></div>
-<button onclick="goHome()" class="bg-gray-400 hover:bg-gray-500 text-white py-2 px-4 rounded">
-    홈으로 돌아가기
-</button>
+    <h1 class="text-2xl font-bold mb-4">데일리 문진 결과</h1>
+    <div id="result-container" class="mb-4"></div>
+    <button onclick="goHome()" >홈으로 돌아가기</button>
 
-<script>
-    const params = new URLSearchParams(window.location.search);
-    const ageGroup = params.get("ageGroup");
-    const answersParam = params.get("answers"); // answers를 URL에서 배열로 받는다
+    <script>
+        const params = new URLSearchParams(window.location.search);
 
-    let answers = [];
-    try {
-      answers = JSON.parse(decodeURIComponent(answersParam));
-    } catch (error) {
-      console.error("답변 데이터 파싱 오류:", error);
-    }
+        // 이미 JSON.stringify → encodeURIComponent 된 걸 가져와서
+        const riskScoresParam = params.get("riskScores");
+        let resultData = {};
+        try {
+          resultData = JSON.parse(decodeURIComponent(riskScoresParam));
+        } catch (e) {
+          console.error("리스크 데이터 파싱 실패:", e);
+          document.getElementById("result-container")
+                  .innerHTML = `<p class="text-red-500">결과를 불러오는데 실패했습니다.</p>`;
+          throw e;
+        }
 
-    const resultContainer = document.getElementById("result-container");
+        const categoryScores = resultData.categoryScores;
+        const totalRisk     = resultData.totalRiskScore;
 
-    // 서버로 POST 요청 보내서 결과 받아오기
-    fetch("http://localhost:8080/api/surveys/submit", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        ageGroup: ageGroup,
-        answers: answers
-      })
-    })
-    .then(response => response.json())
-    .then(data => {
-      // 결과 출력
-      const totalRiskScore = data.totalRiskScore;
-      const categoryScores = data.categoryScores;
+        const container = document.getElementById("result-container");
+        // 카테고리별 점수
+        for (const [category, score] of Object.entries(categoryScores)) {
+          const div = document.createElement("div");
+          div.className = "mb-2";
+          div.innerHTML = `<p class="font-semibold">${category} 위험도: ${score.toFixed(2)}%</p>`;
+          container.appendChild(div);
+        }
 
-      for (const [category, score] of Object.entries(categoryScores)) {
-        const div = document.createElement("div");
-        div.className = "mb-2";
-        div.innerHTML = `<p class="font-semibold">${category} 위험도: ${score.toFixed(2)}%</p>`;
-        resultContainer.appendChild(div);
-      }
+        // 전체 평균
+        const overallDiv = document.createElement("div");
+        const categoryCount = 4;
+        overallDiv.className = "mt-4 font-bold text-lg";
+        overallDiv.innerHTML = `통합 위험도: ${totalRisk.toFixed(2)  / categoryCount}%`;
+        container.appendChild(overallDiv);
 
-      const overallDiv = document.createElement("div");
-      const categoryCount = 4;
-      overallDiv.className = "mt-4 font-bold text-lg";
-      overallDiv.innerHTML = `통합 위험도: ${(totalRiskScore / categoryCount).toFixed(2)}%`;
-      resultContainer.appendChild(overallDiv);
-    })
-    .catch(error => {
-      console.error("데이터 불러오기 오류:", error);
-      resultContainer.innerHTML = `<div class="mt-4 text-red-500">⚠️ 결과를 불러오는데 실패했습니다.</div>`;
-    });
-
-    function goHome() {
-      window.location.href = "/dailySurvey";
-    }
-</script>
+        function goHome() { window.location.href = "/dailySurvey"; }
+    </script>
 </th:block>
 </html>


### PR DESCRIPTION
### DailyAnswer 엔티티 생성
- 기존 erd에서 답변여부와 users_id로 FK 제거
- 가중치(weight) 추가

### DailyAnswerDto 생성
- 응답 데이터를 회원 조회 페이지에서 리스트로 출력 하기 위한 Dto

### DailyAnswerRepository
- DailyAnswer에 대한 레파지토리 생성

### DailySurveyPageController
- DailySurvey의 page에 대한 컨트롤러
- 접속한 회원에 대한 자녀 정보를 목록으로 제공

### DailyAnswerPageController
- 회원의 모든 자녀에 대한 응답 데이터 전달
- 카테고리, 연령대 필터 기능
- DTO 변환

### ChildRepository, ChildService
- 현재 로그인한 유저의 Member.id로 조회 추가

### SurveyRequestDto
- 자녀 정보도 필요하므로 추가

### UserService
- email과 uuid로 User엔티티 조회 추가

### DailySurveyController
- 자녀 엔티티 조회
- 응답 데이터 저장
- 포인트 적립

### ----------중요도 낮음----------

기존 SurveyAdminController에서
데일리 부분에서만의 관리자 컨트롤러로 네이밍 변경
### DailySurveyAdminController
- 전체 경로 수정 (admin/survey + /daily)

### MainController
- 기존 /dailySurvey 제거 (응답 데이터 전달해야해서 다른 컨트롤러에서 따로 관리)

### SecurityConfig
- 로그에 계속 뜨는 /.well-known/** 제거를 위해 추가

### SurveyApiController
- 문진 세트에서 생성할 때, 그룹인지 특별인지 구별하는 컨트롤러 (이전에 올렸는데 주석처리되어 머지되어있어서 다시 커밋..)

### ------html-------
admin>surveys>
### dailyForm, dailList
- 경로 수정 (admin/survey + /daily)

### dailySurvey
- 자녀 셀렉트박스 추가

### dailySurveyResult
- encodeURIComponent된 결과를 가져오도록 수정

### dailyAnswer
- 회원이 자녀의 응답을 조회할 수 있는 페이지
- 자녀 선택 기능
- 연령대, 카테고리 필터 기능