### PR TITLE
0619박지수 | 데일리 문진 응답 관련 기능 수정 & 그룹 문진 응답 관련 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/enums/TargetGroup.java
+++ b/src/main/java/com/example/demo/enums/TargetGroup.java
@@ -7,11 +7,9 @@ public enum TargetGroup {
     KINDERGARTEN("유치원"),
     DAYCARE("어린이집"),
     CHILDRENS_HOME("보육원"),
-    // 검색용 전체(all)
-    ALL("all"),
 
-    // 세트 저장용 통합(various)
-    VARIOUS("various");
+    // 검색용 전체(all)
+    ALL("all");
 
     private final String displayName;
 

--- a/src/main/java/com/example/demo/survey/controller/DailyAnswerPageController.java
+++ b/src/main/java/com/example/demo/survey/controller/DailyAnswerPageController.java
@@ -1,19 +1,16 @@
 package com.example.demo.survey.controller;
 
-import com.example.demo.enums.AgeGroup;
-import com.example.demo.enums.SurveyCategory;
 import com.example.demo.survey.dto.DailyAnswerDto;
-import com.example.demo.survey.entity.DailyAnswer;
-import com.example.demo.survey.repository.DailyAnswerRepository;
+import com.example.demo.survey.dto.DailyAnswerRequest;
+import com.example.demo.survey.entity.DailySurvey;
+import com.example.demo.survey.service.DailyAnswerService;
+import com.example.demo.users.service.ChildService;
+import com.example.demo.users.service.UserService;
 import com.example.demo.users.entity.Child;
 import com.example.demo.users.entity.Users;
 import com.example.demo.users.exception.UserNotFoundException;
-import com.example.demo.users.service.ChildService;
-import com.example.demo.users.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -22,77 +19,81 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.time.Period;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Controller
 @RequiredArgsConstructor
+@RequestMapping("/dailyAnswer")
 public class DailyAnswerPageController {
 
-    private final UserService           userService;
-    private final ChildService          childService;
-    private final DailyAnswerRepository answerRepo;
+    private final UserService userService;
+    private final ChildService childService;
+    private final DailyAnswerService answerService;
 
-    /** 뷰: 필터용 드롭다운 데이터만 전달 */
-    @GetMapping("/dailyAnswer")
-    public String showAnswerPage(Authentication auth, Model model) {
-        String principal = auth.getName();
+    /** 뷰: 이력 페이지 */
+    @GetMapping("/history")
+    public String showHistoryPage(Authentication auth, Model model) {
         Users me;
         try {
-            me = userService.findByUsernameEntity(principal);
+            me = userService.findByUsernameEntity(auth.getName());
         } catch (UserNotFoundException e) {
-            me = userService.findByUuidEntity(principal);
+            me = userService.findByUuidEntity(auth.getName());
         }
-
-        model.addAttribute("children",
-                childService.findByUsersId(me.getId()));
-        model.addAttribute("categories",
-                Arrays.stream(SurveyCategory.values())
-                        .filter(c -> c != SurveyCategory.ALL && c != SurveyCategory.VARIOUS)
-                        .toList());
-        model.addAttribute("ageGroups",
-                Arrays.stream(AgeGroup.values())
-                        .filter(a -> a != AgeGroup.ALL && a != AgeGroup.VARIOUS)
-                        .toList());
-
-        return "dailyAnswer";
+        List<Child> children = childService.findByUsersId(me.getId());
+        model.addAttribute("children", children);
+        return "survey/dailyAnswerHistory";
     }
 
-    /** API: 페이징·필터링된 응답 JSON 반환 */
-    @GetMapping("/api/answers")
+    /** API: 특정 자녀의 답변 이력 조회 */
+    @GetMapping("/api/history/{childId}")
     @ResponseBody
-    public Map<String,Object> getAnswers(
-            @RequestParam(required = false) Long childId,
-            @RequestParam(required = false) SurveyCategory category,
-            @RequestParam(required = false) AgeGroup ageGroup,
-            @RequestParam(defaultValue = "0") int page
+    public List<DailyAnswerDto> getHistoryByChild(@PathVariable Long childId) {
+        return answerService.getAnswersByChild(childId).stream()
+                .map(da -> {
+                    // 나이 계산
+                    LocalDate bday = da.getChild().getBirthday().toLocalDate();
+                    int age = Period.between(bday, LocalDate.now()).getYears();
+                    String childDisplay = da.getChild().getName()
+                            + " (" + da.getChild().getNickname() + ") - " + age + "세";
+                    DailySurvey s = da.getSurvey();
+                    List<String> opts = List.of(
+                            s.getAnswer1(), s.getAnswer2(), s.getAnswer3(),
+                            s.getAnswer4(), s.getAnswer5()
+                    );
+                    // da.getAnswer() 에 저장된 텍스트이므로, 몇 번째인지 찾아서 selectedValue 로 전달
+                    int sel = opts.indexOf(da.getAnswer()) + 1;
+                    return new DailyAnswerDto(
+                            da.getId(),
+                            childDisplay,
+                            da.getCategory().getDisplayName(),
+                            s.getAgeGroup().getDisplayName(),
+                            da.getQuestion(),
+                            da.getAnswer(),
+                            da.getWeight(),
+                            da.getCreatedAt(),
+                            opts,
+                            sel
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    /** API: 답변 수정 */
+    @PutMapping("/api/answer/{id}")
+    @ResponseBody
+    public ResponseEntity<?> updateAnswer(
+            @PathVariable Long id,
+            @RequestBody DailyAnswerRequest req   // DTO 로 받는다!
     ) {
-        Pageable pageable = PageRequest.of(page, 4);
-        Page<DailyAnswer> paged = answerRepo.findByFilters(childId, category, ageGroup, pageable);
+        answerService.updateAnswerValue(id, req.getAnswerValue());
+        return ResponseEntity.ok().build();
+    }
 
-        // content → DTO
-        List<DailyAnswerDto> dtos = paged.map(da -> {
-            // 자녀 display
-            LocalDate bday = da.getChild().getBirthday().toLocalDate();
-            int age = Period.between(bday, LocalDate.now()).getYears();
-            String childDisplay = da.getChild().getName()
-                    + " (" + da.getChild().getNickname() + ") - " + age + "세";
-            return new DailyAnswerDto(
-                    da.getId(),
-                    childDisplay,
-                    da.getCategory().getDisplayName(),
-                    da.getSurvey().getAgeGroup().getDisplayName(),
-                    da.getQuestion(),
-                    da.getAnswer(),
-                    da.getWeight(),
-                    da.getCreatedAt()
-            );
-        }).getContent();
-
-        // 메타데이터 포함
-        Map<String,Object> result = new HashMap<>();
-        result.put("content",       dtos);
-        result.put("currentPage",   paged.getNumber());
-        result.put("totalPages",    paged.getTotalPages());
-        result.put("totalElements", paged.getTotalElements());
-        return result;
+    /** API: 답변 삭제(soft delete) */
+    @DeleteMapping("/api/answer/{id}")
+    @ResponseBody
+    public ResponseEntity<?> deleteAnswer(@PathVariable Long id) {
+        answerService.deleteAnswer(id);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/demo/survey/controller/GroupAnswerController.java
+++ b/src/main/java/com/example/demo/survey/controller/GroupAnswerController.java
@@ -1,0 +1,67 @@
+package com.example.demo.survey.controller;
+
+import com.example.demo.survey.dto.AnswerUpdateRequest;
+import com.example.demo.survey.dto.GroupAnswerDto;
+import com.example.demo.survey.service.GroupAnswerService;
+import com.example.demo.users.entity.Users;
+import com.example.demo.users.exception.UserNotFoundException;
+import com.example.demo.users.service.ChildService;
+import com.example.demo.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("/groupAnswer")
+@RequiredArgsConstructor
+public class GroupAnswerController {
+    private final UserService userService;
+    private final ChildService childService;
+    private final GroupAnswerService answerService;
+
+    /** 뷰: 이력 페이지 */
+    @GetMapping("/history")
+    public String historyPage(Authentication auth, Model model) {
+        Users me;
+        try {
+            me = userService.findByUsernameEntity(auth.getName());
+        } catch (UserNotFoundException e) {
+            me = userService.findByUuidEntity(auth.getName());
+        }
+        model.addAttribute("children", childService.findByUsersId(me.getId()));
+        return "survey/groupAnswerHistory";
+    }
+
+    /** API: 특정 자녀의 답변 이력 조회 */
+    @GetMapping("/api/history/{childId}")
+    @ResponseBody
+    public List<GroupAnswerDto> apiHistory(@PathVariable Long childId) {
+        return answerService.findByChild(childId).stream()
+                .map(GroupAnswerDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    /** API: 답변 수정 */
+    @PutMapping("/api/answer/{id}")
+    @ResponseBody
+    public ResponseEntity<?> update(
+            @PathVariable Long id,
+            @RequestBody AnswerUpdateRequest req) {
+        answerService.updateAnswerValue(id, req.answerValue());
+        return ResponseEntity.ok().build();
+    }
+
+    /** API: 답변 삭제(soft delete) */
+    @DeleteMapping("/api/answer/{id}")
+    @ResponseBody
+    public ResponseEntity<?> delete(@PathVariable Long id) {
+        answerService.deleteAnswer(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/survey/controller/GroupSurveyController.java
+++ b/src/main/java/com/example/demo/survey/controller/GroupSurveyController.java
@@ -1,10 +1,14 @@
 package com.example.demo.survey.controller;
 
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.enums.TargetGroup;
 import com.example.demo.survey.dto.GroupSurveyRequestDto;
 import com.example.demo.survey.dto.GroupSurveyResponseDto;
 import com.example.demo.survey.entity.GroupSurvey;
+import com.example.demo.survey.service.GroupAnswerService;
 import com.example.demo.survey.service.GroupSurveyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,6 +20,7 @@ import java.util.Map;
 public class GroupSurveyController {
 
     private final GroupSurveyService groupSurveyService;
+    private final GroupAnswerService groupAnswerService;
 
     // 1. 연령대 기준 조회
     @GetMapping("/by-age/{ageGroup}")
@@ -62,7 +67,17 @@ public class GroupSurveyController {
 
     // 7. 문항 답변 제출
     @PostMapping("/submit")
-    public Map<String, Object> submitSurvey(@RequestBody GroupSurveyRequestDto dto) {
-        return groupSurveyService.evaluate(dto);
+    public ResponseEntity<Map<String,Object>> submitAndSave(
+            @RequestBody GroupSurveyRequestDto dto) {
+        // 저장
+        groupAnswerService.saveAnswers(
+                dto.getChildId(),
+                AgeGroup.fromValue(dto.getAgeGroup()),
+                TargetGroup.fromValue(dto.getTargetGroup()),
+                dto.getAnswers()
+        );
+        // 평가
+        Map<String,Object> result = groupSurveyService.evaluate(dto);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/example/demo/survey/controller/GroupSurveyPageController.java
+++ b/src/main/java/com/example/demo/survey/controller/GroupSurveyPageController.java
@@ -1,0 +1,54 @@
+package com.example.demo.survey.controller;
+
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.enums.TargetGroup;
+import com.example.demo.users.entity.Child;
+import com.example.demo.users.entity.Users;
+import com.example.demo.users.exception.UserNotFoundException;
+import com.example.demo.users.service.ChildService;
+import com.example.demo.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class GroupSurveyPageController {
+
+    private final UserService  userService;
+    private final ChildService childService;
+
+    @GetMapping("/groupSurvey")
+    public String showPage(Authentication auth, Model model) {
+        // 1) 로그인 사용자 조회
+        Users me;
+        try {
+            me = userService.findByUsernameEntity(auth.getName());
+        } catch (UserNotFoundException e) {
+            me = userService.findByUuidEntity(auth.getName());
+        }
+
+        // 2) 자녀 목록
+        List<Child> children = childService.findByUsersId(me.getId());
+        model.addAttribute("children", children);
+
+        // 3) 연령대·대상 그룹 ENUM 목록
+        model.addAttribute("ageGroups",
+                List.of(AgeGroup.values()).stream()
+                        .filter(a->a!=AgeGroup.ALL && a!=AgeGroup.VARIOUS)
+                        .toList());
+        model.addAttribute("targetGroups",
+                List.of(TargetGroup.values()));
+
+        return "groupSurvey";  // templates/groupSurvey.html
+    }
+
+    @GetMapping("/groupSurvey/result")
+    public String showResultPage() {
+        return "groupSurveyResult";  // templates/groupSurveyResult.html
+    }
+}

--- a/src/main/java/com/example/demo/survey/controller/SpecialAnswerController.java
+++ b/src/main/java/com/example/demo/survey/controller/SpecialAnswerController.java
@@ -1,0 +1,69 @@
+package com.example.demo.survey.controller;
+
+import com.example.demo.survey.dto.AnswerUpdateRequest;
+import com.example.demo.survey.dto.GroupAnswerDto;
+import com.example.demo.survey.dto.SpecialAnswerDto;
+import com.example.demo.survey.service.GroupAnswerService;
+import com.example.demo.survey.service.SpecialAnswerService;
+import com.example.demo.users.entity.Users;
+import com.example.demo.users.exception.UserNotFoundException;
+import com.example.demo.users.service.ChildService;
+import com.example.demo.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("/specialAnswer")
+@RequiredArgsConstructor
+public class SpecialAnswerController {
+    private final UserService userService;
+    private final ChildService childService;
+    private final SpecialAnswerService answerService;
+
+    /** 뷰: 이력 페이지 */
+    @GetMapping("/history")
+    public String historyPage(Authentication auth, Model model) {
+        Users me;
+        try {
+            me = userService.findByUsernameEntity(auth.getName());
+        } catch (UserNotFoundException e) {
+            me = userService.findByUuidEntity(auth.getName());
+        }
+        model.addAttribute("children", childService.findByUsersId(me.getId()));
+        return "survey/specialAnswerHistory";
+    }
+
+    /** API: 특정 자녀의 답변 이력 조회 */
+    @GetMapping("/api/history/{childId}")
+    @ResponseBody
+    public List<SpecialAnswerDto> apiHistory(@PathVariable Long childId) {
+        return answerService.findByChild(childId).stream()
+                .map(SpecialAnswerDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    /** API: 답변 수정 */
+    @PutMapping("/api/answer/{id}")
+    @ResponseBody
+    public ResponseEntity<?> update(
+            @PathVariable Long id,
+            @RequestBody AnswerUpdateRequest req) {
+        answerService.updateAnswerValue(id, req.answerValue());
+        return ResponseEntity.ok().build();
+    }
+
+    /** API: 답변 삭제(soft delete) */
+    @DeleteMapping("/api/answer/{id}")
+    @ResponseBody
+    public ResponseEntity<?> delete(@PathVariable Long id) {
+        answerService.deleteAnswer(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/survey/controller/SpecialSurveyController.java
+++ b/src/main/java/com/example/demo/survey/controller/SpecialSurveyController.java
@@ -1,8 +1,11 @@
 package com.example.demo.survey.controller;
 
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.enums.SurveyCategory;
 import com.example.demo.survey.dto.SpecialSurveyRequestDto;
 import com.example.demo.survey.dto.SpecialSurveyResponseDto;
 import com.example.demo.survey.entity.SpecialSurvey;
+import com.example.demo.survey.service.SpecialAnswerService;
 import com.example.demo.survey.service.SpecialSurveyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,14 +20,15 @@ import java.util.Map;
 public class SpecialSurveyController {
 
     private final SpecialSurveyService specialSurveyService;
+    private final SpecialAnswerService specialAnswerService;
 
     // 1. 연령대 기준 조회
     @GetMapping("/by-age/{ageGroup}")
-    public List<SpecialSurveyResponseDto> getByAgeGroup(@PathVariable String ageGroup) {
+    public List<SpecialSurveyResponseDto> getSurveysByAgeGroup(@PathVariable String ageGroup) {
         return specialSurveyService.getByAgeGroup(ageGroup);
     }
 
-    // 2. 카테고리 기준 조회
+    // 3. 문항 카테고리별 조회
     @GetMapping
     public List<SpecialSurveyResponseDto> getSurveysByCategory(@RequestParam(required = false) String category) {
         if (category == null || category.isBlank()) {
@@ -33,14 +37,14 @@ public class SpecialSurveyController {
         return specialSurveyService.getBySurveyCategory(category);
     }
 
-    // 3. 설문 등록
+    // 4. 신규 문항 생성 (surveySetId 파라미터로 받음)
     @PostMapping
     public String createSurvey(@RequestBody SpecialSurvey dto, @RequestParam Long surveySetId) {
         specialSurveyService.create(dto, surveySetId);
         return "생성 완료";
     }
 
-    // 4. 설문 수정
+    // 5. 기존 문항 수정
     @PutMapping("/{id}")
     public String updateSurvey(@PathVariable Long id, @RequestBody SpecialSurvey dto) {
         dto.setId(id);
@@ -48,16 +52,26 @@ public class SpecialSurveyController {
         return "수정 완료";
     }
 
-    // 5. 설문 삭제
+    // 6. 문항 삭제
     @DeleteMapping("/{id}")
     public String deleteSurvey(@PathVariable Long id) {
         specialSurveyService.delete(id);
         return "삭제 완료";
     }
 
-    // 6. 문항 답변 제출
+    // 7. 문항 답변 제출
     @PostMapping("/submit")
-    public Map<String, Object> submitSurvey(@RequestBody SpecialSurveyRequestDto dto) {
-        return specialSurveyService.evaluate(dto);
+    public ResponseEntity<Map<String,Object>> submitAndSave(
+            @RequestBody SpecialSurveyRequestDto dto) {
+        // 저장
+        specialAnswerService.saveAnswers(
+                dto.getChildId(),
+                AgeGroup.fromValue(dto.getAgeGroup()),
+                SurveyCategory.fromValue(dto.getCategory()),
+                dto.getAnswers()
+        );
+        // 평가
+        Map<String,Object> result = specialSurveyService.evaluate(dto);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/example/demo/survey/controller/SpecialSurveyPageController.java
+++ b/src/main/java/com/example/demo/survey/controller/SpecialSurveyPageController.java
@@ -1,0 +1,55 @@
+package com.example.demo.survey.controller;
+
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.enums.SurveyCategory;
+import com.example.demo.enums.TargetGroup;
+import com.example.demo.users.entity.Child;
+import com.example.demo.users.entity.Users;
+import com.example.demo.users.exception.UserNotFoundException;
+import com.example.demo.users.service.ChildService;
+import com.example.demo.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class SpecialSurveyPageController {
+
+    private final UserService  userService;
+    private final ChildService childService;
+
+    @GetMapping("/specialSurvey")
+    public String showPage(Authentication auth, Model model) {
+        // 1) 로그인 사용자 조회
+        Users me;
+        try {
+            me = userService.findByUsernameEntity(auth.getName());
+        } catch (UserNotFoundException e) {
+            me = userService.findByUuidEntity(auth.getName());
+        }
+
+        // 2) 자녀 목록
+        List<Child> children = childService.findByUsersId(me.getId());
+        model.addAttribute("children", children);
+
+        // 3) 연령대·카테고리 ENUM 목록
+        model.addAttribute("ageGroups",
+                List.of(AgeGroup.values()).stream()
+                        .filter(a->a!=AgeGroup.ALL && a!=AgeGroup.VARIOUS)
+                        .toList());
+        model.addAttribute("categories",
+                List.of(SurveyCategory.values()));
+
+        return "specialSurvey";  // templates/specialSurvey.html
+    }
+
+    @GetMapping("/specialSurvey/result")
+    public String showResultPage() {
+        return "specialSurveyResult";  // templates/specialSurveyResult.html
+    }
+}

--- a/src/main/java/com/example/demo/survey/dto/AnswerUpdateRequest.java
+++ b/src/main/java/com/example/demo/survey/dto/AnswerUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.example.demo.survey.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AnswerUpdateRequest(
+        @JsonProperty("answerValue") int answerValue
+) {}

--- a/src/main/java/com/example/demo/survey/dto/DailyAnswerDto.java
+++ b/src/main/java/com/example/demo/survey/dto/DailyAnswerDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor
@@ -20,4 +21,7 @@ public class DailyAnswerDto {
     private String         answer;
     private Integer         weight;
     private LocalDateTime  createdAt;
+
+    private List<String> possibleAnswers;  // survey.answer1~answer5
+    private Integer        selectedValue;    // 1~5 중 현재 답변
 }

--- a/src/main/java/com/example/demo/survey/dto/DailyAnswerRequest.java
+++ b/src/main/java/com/example/demo/survey/dto/DailyAnswerRequest.java
@@ -1,0 +1,17 @@
+package com.example.demo.survey.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DailyAnswerRequest {
+    private int answerValue;   // 클라이언트에서는 { "answerValue": 4 } 처럼 보냄
+    // 반드시 getter/setter 추가
+    public int getAnswerValue() {
+        return answerValue;
+    }
+    public void setAnswerValue(int answerValue) {
+        this.answerValue = answerValue;
+    }
+}

--- a/src/main/java/com/example/demo/survey/dto/GroupAnswerDto.java
+++ b/src/main/java/com/example/demo/survey/dto/GroupAnswerDto.java
@@ -1,0 +1,56 @@
+package com.example.demo.survey.dto;
+
+import com.example.demo.survey.entity.GroupAnswer;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 이력 API 응답용 DTO */
+@Getter @Setter
+public class GroupAnswerDto {
+    private Long id;
+    private String childDisplay;
+    private String category;
+    private String ageGroup;
+    private String targetGroup;
+    private String question;
+    private String answer;
+    private Integer weight;
+    private LocalDateTime createdAt;
+
+    // 버튼 모달용 옵션 목록
+    private List<String> possibleAnswers;
+    // 현재 선택된 답 (1~5)
+    private int selectedValue;
+
+    public static GroupAnswerDto fromEntity(GroupAnswer a) {
+        GroupAnswerDto d = new GroupAnswerDto();
+        d.setId(a.getId());
+        // 자녀 표시: 이름(닉네임)-나이
+        var c = a.getChild();
+        var age = c.getBirthday().toLocalDate()
+                .until(LocalDate.now()).getYears();
+        d.setChildDisplay(c.getName()+"("+c.getNickname()+") - "+age+"세");
+
+        d.setCategory(a.getCategory().getDisplayName());
+        d.setAgeGroup(a.getAgeGroup().getDisplayName());
+        d.setTargetGroup(a.getTargetGroup().getDisplayName());
+        d.setQuestion(a.getQuestion());
+        d.setAnswer(a.getAnswer());
+        d.setWeight(a.getWeight());
+        d.setCreatedAt(a.getCreatedAt());
+
+        // survey 엔티티에서 옵션 꺼내기
+        var s = a.getSurvey();
+        List<String> opts = List.of(
+                s.getAnswer1(), s.getAnswer2(),
+                s.getAnswer3(), s.getAnswer4(), s.getAnswer5()
+        );
+        d.setPossibleAnswers(opts);
+        d.setSelectedValue(opts.indexOf(a.getAnswer())+1);
+        return d;
+    }
+}

--- a/src/main/java/com/example/demo/survey/dto/GroupSurveyRequestDto.java
+++ b/src/main/java/com/example/demo/survey/dto/GroupSurveyRequestDto.java
@@ -8,8 +8,8 @@ import java.util.List;
 @Getter
 @Setter
 public class GroupSurveyRequestDto {
-    private String ageGroup;
-    private String targetGroup;
-    private List<Integer> answers;
-    private Long surveySetId;
+    private Long childId;       // 추가: 자녀 ID
+    private String ageGroup;    // 연령대
+    private String targetGroup; // 대상 그룹
+    private List<Integer> answers; // 문항별 응답 값(1~5)
 }

--- a/src/main/java/com/example/demo/survey/dto/SpecialAnswerDto.java
+++ b/src/main/java/com/example/demo/survey/dto/SpecialAnswerDto.java
@@ -1,0 +1,55 @@
+package com.example.demo.survey.dto;
+
+import com.example.demo.survey.entity.GroupAnswer;
+import com.example.demo.survey.entity.SpecialAnswer;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 이력 API 응답용 DTO */
+@Getter @Setter
+public class SpecialAnswerDto {
+    private Long id;
+    private String childDisplay;
+    private String category;
+    private String ageGroup;
+    private String question;
+    private String answer;
+    private Integer weight;
+    private LocalDateTime createdAt;
+
+    // 버튼 모달용 옵션 목록
+    private List<String> possibleAnswers;
+    // 현재 선택된 답 (1~5)
+    private int selectedValue;
+
+    public static SpecialAnswerDto fromEntity(SpecialAnswer a) {
+        SpecialAnswerDto d = new SpecialAnswerDto();
+        d.setId(a.getId());
+        // 자녀 표시: 이름(닉네임)-나이
+        var c = a.getChild();
+        var age = c.getBirthday().toLocalDate()
+                .until(LocalDate.now()).getYears();
+        d.setChildDisplay(c.getName()+"("+c.getNickname()+") - "+age+"세");
+
+        d.setCategory(a.getCategory().getDisplayName());
+        d.setAgeGroup(a.getAgeGroup().getDisplayName());
+        d.setQuestion(a.getQuestion());
+        d.setAnswer(a.getAnswer());
+        d.setWeight(a.getWeight());
+        d.setCreatedAt(a.getCreatedAt());
+
+        // survey 엔티티에서 옵션 꺼내기
+        var s = a.getSurvey();
+        List<String> opts = List.of(
+                s.getAnswer1(), s.getAnswer2(),
+                s.getAnswer3(), s.getAnswer4(), s.getAnswer5()
+        );
+        d.setPossibleAnswers(opts);
+        d.setSelectedValue(opts.indexOf(a.getAnswer())+1);
+        return d;
+    }
+}

--- a/src/main/java/com/example/demo/survey/dto/SpecialSurveyRequestDto.java
+++ b/src/main/java/com/example/demo/survey/dto/SpecialSurveyRequestDto.java
@@ -8,6 +8,8 @@ import java.util.List;
 @Getter
 @Setter
 public class SpecialSurveyRequestDto {
-    private String ageGroup;
-    private List<Integer> answers;
+    private Long childId;       // 추가: 자녀 ID
+    private String ageGroup;    // 연령대
+    private String category; // 대상 그룹
+    private List<Integer> answers; // 문항별 응답 값(1~5)
 }

--- a/src/main/java/com/example/demo/survey/entity/GroupAnswer.java
+++ b/src/main/java/com/example/demo/survey/entity/GroupAnswer.java
@@ -1,0 +1,55 @@
+// com.example.demo.survey.entity.GroupAnswer.java
+package com.example.demo.survey.entity;
+
+import com.example.demo.entity.BaseEntity;
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.users.entity.Child;
+import com.example.demo.enums.TargetGroup;
+import com.example.demo.enums.SurveyCategory;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name="group_answer")
+@Getter @Setter
+public class GroupAnswer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_answer_id")
+    private Long id;
+
+    //  그룹 문진 항목 (group_survey) 과 N:1
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", nullable = false)
+    private GroupSurvey survey;
+
+    // 자녀 (child) 과 N:1
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Child child;
+
+    // 연령대
+    @Column(name = "age_group", nullable = false)
+    private AgeGroup ageGroup;
+
+    // 타켓 그룹(유치원, 어린이집 등)
+    @Column(name = "target_group", nullable = false)
+    private TargetGroup targetGroup;
+
+    // GroupSurvey.category 와 같은 값
+    @Column(nullable = false)
+    private SurveyCategory category;
+
+    @Column(nullable = false)
+    private String question;
+
+    // 실제 사용자가 선택한 답변 텍스트
+    @Column(nullable = false)
+    private String answer;
+
+    // 가중치(위험도 도출 시 사용)
+    @Column(nullable = false)
+    private Integer weight;
+}

--- a/src/main/java/com/example/demo/survey/entity/GroupSurvey.java
+++ b/src/main/java/com/example/demo/survey/entity/GroupSurvey.java
@@ -23,14 +23,12 @@ public class GroupSurvey extends BaseEntity implements BaseSurvey {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Convert(converter = com.example.demo.converter.AgeGroupConverter.class)
     @Column(name = "age_group", nullable = false)
     private AgeGroup ageGroup;
 
     @Column(name = "question", nullable = false)
     private String question;
 
-    @Convert(converter = com.example.demo.converter.SurveyCategoryConverter.class)
     @Column(nullable = false)
     private SurveyCategory category;
 
@@ -38,7 +36,6 @@ public class GroupSurvey extends BaseEntity implements BaseSurvey {
     @JsonIgnore
     private List<SurveySet> surveySets = new ArrayList<>();
 
-    @Convert(converter = com.example.demo.converter.TargetGroupConverter.class)
     @Column(name = "target_group", nullable = false)
     private TargetGroup targetGroup;
 
@@ -65,7 +62,6 @@ public class GroupSurvey extends BaseEntity implements BaseSurvey {
 
     @Column(name = "calculated_score", nullable = false)
     private int calculatedScore;
-
 
 
     @Override

--- a/src/main/java/com/example/demo/survey/entity/SpecialAnswer.java
+++ b/src/main/java/com/example/demo/survey/entity/SpecialAnswer.java
@@ -1,0 +1,51 @@
+// com.example.demo.survey.entity.GroupAnswer.java
+package com.example.demo.survey.entity;
+
+import com.example.demo.entity.BaseEntity;
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.users.entity.Child;
+import com.example.demo.enums.TargetGroup;
+import com.example.demo.enums.SurveyCategory;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name="special_answer")
+@Getter @Setter
+public class SpecialAnswer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "special_answer_id")
+    private Long id;
+
+    //  특별 문진 항목 (special_survey) 과 N:1
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", nullable = false)
+    private SpecialSurvey survey;
+
+    // 자녀 (child) 과 N:1
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Child child;
+
+    // 연령대
+    @Column(name = "age_group", nullable = false)
+    private AgeGroup ageGroup;
+
+    // SpecialSurvey.category 와 같은 값
+    @Column(nullable = false)
+    private SurveyCategory category;
+
+    @Column(nullable = false)
+    private String question;
+
+    // 실제 사용자가 선택한 답변 텍스트
+    @Column(nullable = false)
+    private String answer;
+
+    // 가중치(위험도 도출 시 사용)
+    @Column(nullable = false)
+    private Integer weight;
+}

--- a/src/main/java/com/example/demo/survey/entity/SpecialSurvey.java
+++ b/src/main/java/com/example/demo/survey/entity/SpecialSurvey.java
@@ -31,11 +31,9 @@ public class SpecialSurvey extends BaseEntity implements BaseSurvey{
     @Column(name = "age_group", nullable = false)
     private AgeGroup ageGroup;
 
-
     @Column(nullable = false)
     private String question;
 
-    @Convert(converter = com.example.demo.converter.SurveyCategoryConverter.class)
     @Column(nullable = false)
     private SurveyCategory category;
 
@@ -43,10 +41,8 @@ public class SpecialSurvey extends BaseEntity implements BaseSurvey{
     @JsonIgnore
     private List<SurveySet> surveySets = new ArrayList<>();
 
-
     @Column(nullable = false)
     private int weight;
-
 
     @Column(nullable = false)
     private String answer1;

--- a/src/main/java/com/example/demo/survey/repository/DailyAnswerRepository.java
+++ b/src/main/java/com/example/demo/survey/repository/DailyAnswerRepository.java
@@ -34,4 +34,6 @@ public interface DailyAnswerRepository extends JpaRepository<DailyAnswer, Long> 
             Pageable pageable
     );
 
+    List<DailyAnswer> findByChildIdOrderByCreatedAtDesc(Long childId);
+
 }

--- a/src/main/java/com/example/demo/survey/repository/GroupAnswerRepository.java
+++ b/src/main/java/com/example/demo/survey/repository/GroupAnswerRepository.java
@@ -1,0 +1,18 @@
+// com.example.demo.survey.repository.GroupAnswerRepository.java
+package com.example.demo.survey.repository;
+
+import com.example.demo.survey.entity.GroupAnswer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GroupAnswerRepository extends JpaRepository<GroupAnswer, Long> {
+    List<GroupAnswer> findByChildIdOrderByCreatedAtDesc(Long childId);
+    Page<GroupAnswer> findByChildIdAndAgeGroupAndTargetGroup(
+            Long childId,
+            com.example.demo.enums.AgeGroup ageGroup,
+            com.example.demo.enums.TargetGroup targetGroup,
+            Pageable pageable);
+}

--- a/src/main/java/com/example/demo/survey/repository/SpecialAnswerRepository.java
+++ b/src/main/java/com/example/demo/survey/repository/SpecialAnswerRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.survey.repository;
+
+import com.example.demo.survey.entity.SpecialAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface SpecialAnswerRepository extends JpaRepository<SpecialAnswer, Long> {
+    List<SpecialAnswer> findByChildIdOrderByCreatedAtDesc(Long childId);
+}

--- a/src/main/java/com/example/demo/survey/service/DailyAnswerService.java
+++ b/src/main/java/com/example/demo/survey/service/DailyAnswerService.java
@@ -1,0 +1,47 @@
+package com.example.demo.survey.service;
+
+import com.example.demo.survey.entity.DailyAnswer;
+import com.example.demo.survey.entity.DailySurvey;
+import com.example.demo.survey.repository.DailyAnswerRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DailyAnswerService {
+    private final DailyAnswerRepository repo;
+
+    public List<DailyAnswer> getAnswersByChild(Long childId) {
+        return repo.findByChildIdOrderByCreatedAtDesc(childId);
+    }
+
+    public void updateAnswerValue(Long id, int value) {
+        DailyAnswer da = repo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("답변이 없습니다. id=" + id));
+
+        DailySurvey s = da.getSurvey();
+        String newText;
+        switch (value) {
+            case 1: newText = s.getAnswer1(); break;
+            case 2: newText = s.getAnswer2(); break;
+            case 3: newText = s.getAnswer3(); break;
+            case 4: newText = s.getAnswer4(); break;
+            case 5: newText = s.getAnswer5(); break;
+            default: throw new IllegalArgumentException("유효한 값(1~5)이 아닙니다: " + value);
+        }
+
+        da.setAnswer(newText);
+        repo.save(da);
+    }
+
+    public void deleteAnswer(Long id) {
+        DailyAnswer da = repo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("답변을 찾을 수 없습니다."));
+        da.markAsDeleted();  // BaseEntity 의 soft-delete 메서드
+        repo.save(da);
+    }
+}
+

--- a/src/main/java/com/example/demo/survey/service/GroupAnswerService.java
+++ b/src/main/java/com/example/demo/survey/service/GroupAnswerService.java
@@ -1,0 +1,113 @@
+package com.example.demo.survey.service;
+
+import com.example.demo.survey.entity.GroupAnswer;
+import com.example.demo.survey.repository.GroupAnswerRepository;
+import com.example.demo.survey.entity.GroupSurvey;
+import com.example.demo.survey.repository.GroupSurveyRepository;
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.enums.TargetGroup;
+import com.example.demo.users.entity.Child;
+import com.example.demo.users.service.ChildService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupAnswerService {
+    private final GroupAnswerRepository answerRepo;
+    private final ChildService childService;
+    private final GroupSurveyRepository surveyRepo;
+
+    // 생성
+    @Transactional
+    public void saveAnswers(Long childId,
+                            AgeGroup ageGroup,
+                            TargetGroup targetGroup,
+                            List<Integer> answers) {
+        Child child = childService.findById(childId);
+        List<GroupSurvey> surveys = surveyRepo.findByAgeGroupAndDeletedFalse(ageGroup).stream()
+                .filter(gs -> gs.getTargetGroup().filter(t->t == targetGroup).isPresent())
+                .toList();
+        if (surveys.size() != answers.size()) {
+            throw new IllegalArgumentException("문진 항목 수와 응답 수 불일치");
+        }
+        for (int i = 0; i < surveys.size(); i++) {
+            GroupSurvey s = surveys.get(i);
+            int idx = answers.get(i);
+            String text = switch(idx) {
+                case 1 -> s.getAnswer1();
+                case 2 -> s.getAnswer2();
+                case 3 -> s.getAnswer3();
+                case 4 -> s.getAnswer4();
+                case 5 -> s.getAnswer5();
+                default -> throw new IllegalArgumentException("1~5 사이 값 필요");
+            };
+            GroupAnswer a = new GroupAnswer();
+            a.setSurvey(s);
+            a.setChild(child);
+            a.setAgeGroup(ageGroup);
+            a.setTargetGroup(targetGroup);
+            a.setCategory(s.getCategory());
+            a.setQuestion(s.getQuestion());
+            a.setAnswer(text);
+            a.setWeight(s.getWeight());
+            answerRepo.save(a);
+        }
+    }
+
+    public List<GroupAnswer> findByChild(Long childId) {
+        return answerRepo.findByChildIdOrderByCreatedAtDesc(childId);
+    }
+
+    // 수정
+    @Transactional
+    public void updateAnswer(Long id, int newValue) {
+        GroupAnswer a = answerRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("답변 없음: " + id));
+        GroupSurvey s = surveyRepo.findById(a.getSurvey().getId())
+                .orElseThrow(() -> new EntityNotFoundException("문진 항목 없음"));
+        String newText = switch(newValue) {
+            case 1 -> s.getAnswer1();
+            case 2 -> s.getAnswer2();
+            case 3 -> s.getAnswer3();
+            case 4 -> s.getAnswer4();
+            case 5 -> s.getAnswer5();
+            default -> throw new IllegalArgumentException("1~5 사이 값 필요");
+        };
+        a.setAnswer(newText);
+        answerRepo.save(a);
+    }
+
+    // API: 답변 수정
+    @Transactional
+    public void updateAnswerValue(Long id, int newValue) {
+        GroupAnswer a = answerRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("답변없음 "+id));
+        GroupSurvey s = surveyRepo.findById(a.getSurvey().getId())
+                .orElseThrow(() -> new EntityNotFoundException("설문없음 "+a.getSurvey().getId()));
+        String newText = switch (newValue) {
+            case 1 -> s.getAnswer1();
+            case 2 -> s.getAnswer2();
+            case 3 -> s.getAnswer3();
+            case 4 -> s.getAnswer4();
+            case 5 -> s.getAnswer5();
+            default -> throw new IllegalArgumentException("1~5 사이 값 필요");
+        };
+        a.setAnswer(newText);
+        answerRepo.save(a);
+    }
+
+    // 답변 삭제(soft delete)
+    @Transactional
+    public void deleteAnswer(Long id) {
+        GroupAnswer a = answerRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("답변없음 "+id));
+        a.markAsDeleted();
+        answerRepo.save(a);
+    }
+
+}

--- a/src/main/java/com/example/demo/survey/service/GroupSurveyService.java
+++ b/src/main/java/com/example/demo/survey/service/GroupSurveyService.java
@@ -91,18 +91,41 @@ public class GroupSurveyService {
     }
 
     @Transactional
-    public Map<String, Object> evaluate(GroupSurveyRequestDto dto) {
+    public Map<String,Object> evaluate(GroupSurveyRequestDto dto) {
         AgeGroup ag = AgeGroup.fromValue(dto.getAgeGroup());
-        List<GroupSurvey> surveys = groupSurveyRepository.findByAgeGroupAndDeletedFalse(ag);
+        String tgt = dto.getTargetGroup();
+        boolean allTargets = (tgt == null || tgt.isBlank() || "all".equalsIgnoreCase(tgt));
+        TargetGroup tg = allTargets
+                ? null
+                : TargetGroup.fromValue(tgt);
 
+        // 1) DB에서는 오직 연령대만으로 꺼냄
+        List<GroupSurvey> surveys = groupSurveyRepository
+                .findByAgeGroupAndDeletedFalse(ag);
+
+        // 2) 대상 그룹이 all이 아니면, 자바에서 enum 동등비교 필터
+        if (!allTargets) {
+            surveys = surveys.stream()
+                    .filter(gs ->
+                            gs.getTargetGroup()
+                                    .filter(enumTg -> enumTg == tg)
+                                    .isPresent()
+                    )
+                    .toList();
+        }
+
+        // 3) 개수 검증
         if (surveys.size() != dto.getAnswers().size()) {
-            throw new IllegalArgumentException("답변 수가 문진 수와 다릅니다.");
+            throw new IllegalArgumentException(
+                    "답변 수가 문진 수와 다릅니다. 서버측 설문 "
+                            + surveys.size() + "개, 클라이언트측 응답 "
+                            + dto.getAnswers().size() + "개"
+            );
         }
 
         double totalScore = 0;
         Map<SurveyCategory, Double> categoryScores = new HashMap<>();
         Map<SurveyCategory, Integer> categoryWeights = new HashMap<>();
-
         for (int i = 0; i < surveys.size(); i++) {
             GroupSurvey survey = surveys.get(i);
             int answer = dto.getAnswers().get(i);
@@ -110,22 +133,17 @@ public class GroupSurveyService {
             double score = survey.getWeight() * multiplier;
             totalScore += score;
 
-            SurveyCategory category = survey.getCategory();
-            categoryScores.put(category, categoryScores.getOrDefault(category, 0.0) + score);
-            categoryWeights.put(category, categoryWeights.getOrDefault(category, 0) + survey.getWeight());
+            SurveyCategory cat = survey.getCategory();
+            categoryScores.merge(cat, score, Double::sum);
+            categoryWeights.merge(cat, survey.getWeight(), Integer::sum);
         }
+        categoryScores.replaceAll((cat, scr) -> (scr / categoryWeights.get(cat)) * 100);
 
-        categoryScores.replaceAll((category, score) ->
-                (score / categoryWeights.get(category)) * 100);
-
-        Map<String, Object> result = new HashMap<>();
+        Map<String,Object> result = new HashMap<>();
         result.put("totalRiskScore", totalScore);
-
-        Map<String, Double> convertedCategoryScores = new HashMap<>();
-        categoryScores.forEach((category, score) ->
-                convertedCategoryScores.put(category.getDisplayName(), score));
-
-        result.put("categoryScores", convertedCategoryScores);
+        Map<String,Double> outCat = new HashMap<>();
+        categoryScores.forEach((cat, scr) -> outCat.put(cat.getDisplayName(), scr));
+        result.put("categoryScores", outCat);
 
         return result;
     }

--- a/src/main/java/com/example/demo/survey/service/SpecialAnswerService.java
+++ b/src/main/java/com/example/demo/survey/service/SpecialAnswerService.java
@@ -1,0 +1,114 @@
+package com.example.demo.survey.service;
+
+import com.example.demo.enums.SurveyCategory;
+import com.example.demo.survey.entity.SpecialAnswer;
+import com.example.demo.survey.entity.SpecialSurvey;
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.survey.repository.SpecialAnswerRepository;
+import com.example.demo.survey.repository.SpecialSurveyRepository;
+import com.example.demo.users.entity.Child;
+import com.example.demo.users.service.ChildService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SpecialAnswerService {
+    private final SpecialAnswerRepository answerRepo;
+    private final ChildService childService;
+    private final SpecialSurveyRepository surveyRepo;
+
+    // 생성
+    @Transactional
+    public void saveAnswers(Long childId,
+                            AgeGroup ageGroup,
+                            SurveyCategory category,
+                            List<Integer> answers) {
+        Child child = childService.findById(childId);
+        List<SpecialSurvey> surveys = surveyRepo
+                .findByAgeGroupAndDeletedFalse(ageGroup)
+                .stream()
+                .filter(s -> s.getCategory() == category)
+                .toList();
+        if (surveys.size() != answers.size()) {
+            throw new IllegalArgumentException("문진 항목 수와 응답 수 불일치");
+        }
+        for (int i = 0; i < surveys.size(); i++) {
+            SpecialSurvey s = surveys.get(i);
+            int idx = answers.get(i);
+            String text = switch(idx) {
+                case 1 -> s.getAnswer1();
+                case 2 -> s.getAnswer2();
+                case 3 -> s.getAnswer3();
+                case 4 -> s.getAnswer4();
+                case 5 -> s.getAnswer5();
+                default -> throw new IllegalArgumentException("1~5 사이 값 필요");
+            };
+            SpecialAnswer a = new SpecialAnswer();
+            a.setSurvey(s);
+            a.setChild(child);
+            a.setAgeGroup(ageGroup);
+            a.setCategory(s.getCategory());
+            a.setQuestion(s.getQuestion());
+            a.setAnswer(text);
+            a.setWeight(s.getWeight());
+            answerRepo.save(a);
+        }
+    }
+
+    public List<SpecialAnswer> findByChild(Long childId) {
+        return answerRepo.findByChildIdOrderByCreatedAtDesc(childId);
+    }
+
+    // 수정
+    @Transactional
+    public void updateAnswer(Long id, int newValue) {
+        SpecialAnswer a = answerRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("답변 없음: " + id));
+        SpecialSurvey s = surveyRepo.findById(a.getSurvey().getId())
+                .orElseThrow(() -> new EntityNotFoundException("문진 항목 없음"));
+        String newText = switch(newValue) {
+            case 1 -> s.getAnswer1();
+            case 2 -> s.getAnswer2();
+            case 3 -> s.getAnswer3();
+            case 4 -> s.getAnswer4();
+            case 5 -> s.getAnswer5();
+            default -> throw new IllegalArgumentException("1~5 사이 값 필요");
+        };
+        a.setAnswer(newText);
+        answerRepo.save(a);
+    }
+
+    // API: 답변 수정
+    @Transactional
+    public void updateAnswerValue(Long id, int newValue) {
+        SpecialAnswer a = answerRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("답변없음 "+id));
+        SpecialSurvey s = surveyRepo.findById(a.getSurvey().getId())
+                .orElseThrow(() -> new EntityNotFoundException("설문없음 "+a.getSurvey().getId()));
+        String newText = switch (newValue) {
+            case 1 -> s.getAnswer1();
+            case 2 -> s.getAnswer2();
+            case 3 -> s.getAnswer3();
+            case 4 -> s.getAnswer4();
+            case 5 -> s.getAnswer5();
+            default -> throw new IllegalArgumentException("1~5 사이 값 필요");
+        };
+        a.setAnswer(newText);
+        answerRepo.save(a);
+    }
+
+    // 답변 삭제(soft delete)
+    @Transactional
+    public void deleteAnswer(Long id) {
+        SpecialAnswer a = answerRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("답변없음 "+id));
+        a.markAsDeleted();
+        answerRepo.save(a);
+    }
+
+}

--- a/src/main/resources/templates/groupSurvey.html
+++ b/src/main/resources/templates/groupSurvey.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>그룹 문진</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<th:block layout:fragment="content">
+    <div class="max-w-4xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-6">그룹 문진</h1>
+
+        <!-- 1) 자녀 선택 -->
+        <div class="mb-4">
+            <label class="block mb-1 font-semibold">자녀 선택</label>
+            <select id="childSelect" class="border p-2 rounded w-64">
+                <option value="">-- 자녀를 선택하세요 --</option>
+                <option th:each="c : ${children}"
+                        th:value="${c.id}"
+                        th:text="${c.name + ' (' + c.nickname + ')'}">
+                </option>
+            </select>
+        </div>
+
+        <!-- 2) 연령대 선택 -->
+        <div class="mb-4">
+            <label class="block mb-1 font-semibold">연령대</label>
+            <select id="ageSelect" class="border p-2 rounded w-64">
+                <option value="">-- 연령대를 선택하세요 --</option>
+                <option th:each="ag : ${ageGroups}"
+                        th:value="${ag.name()}"
+                        th:text="${ag.displayName}">
+                </option>
+            </select>
+        </div>
+
+        <!-- 3) 대상 그룹 선택 -->
+        <div class="mb-4">
+            <label class="block mb-1 font-semibold">대상 그룹</label>
+            <select id="targetSelect" class="border p-2 rounded w-64">
+                <option value="">-- 대상그룹을 선택하세요 --</option>
+                <option th:each="tg : ${targetGroups}"
+                        th:if="${tg != T(com.example.demo.enums.TargetGroup).ALL}"
+                        th:value="${tg.name()}"
+                        th:text="${tg.displayName}">
+                </option>
+            </select>
+        </div>
+
+        <!-- 4) 문진 출력 영역 -->
+        <div id="surveyContainer" class="mb-6 space-y-4"></div>
+
+        <!-- 5) 제출 버튼 -->
+        <button id="submitBtn"
+                class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
+            제출하기
+        </button>
+    </div>
+
+    <script>
+        const childSelect   = document.getElementById('childSelect');
+        const ageSelect     = document.getElementById('ageSelect');
+        const targetSelect  = document.getElementById('targetSelect');
+        const container     = document.getElementById('surveyContainer');
+        const submitBtn     = document.getElementById('submitBtn');
+        let surveys = [];
+
+        function loadSurveys() {
+          const age = ageSelect.value;
+          if (!age) { container.innerHTML=''; return; }
+
+          fetch(`/api/group-surveys/by-age/${encodeURIComponent(age)}`)
+            .then(r => r.ok ? r.json() : Promise.reject())
+            .then(data => {
+              // 대상 그룹 필터링
+              const tg = targetSelect.value;
+              surveys = tg
+                ? data.filter(s => s.targetGroup===document.querySelector('#targetSelect option:checked').text)
+                : data;
+              renderSurveys();
+            })
+            .catch(() => alert('문진 데이터를 불러오는 중 오류 발생'));
+        }
+
+        ageSelect .addEventListener('change', loadSurveys);
+        targetSelect.addEventListener('change', loadSurveys);
+
+        function renderSurveys() {
+          container.innerHTML = '';
+          surveys.forEach((s, i) => {
+            const div = document.createElement('div');
+            div.className = 'border p-4 rounded';
+            div.innerHTML = `
+              <p class="font-semibold mb-2">Q${i+1}. ${s.question} <span class="text-sm text-gray-500">(${s.category})</span></p>
+              ${[1,2,3,4,5].map(v=>
+                `<label class="block"><input type="radio"
+                      name="q${s.id}" value="${v}"> ${s['answer'+v]}</label>`
+              ).join('')}
+            `;
+            container.appendChild(div);
+          });
+        }
+
+        submitBtn.addEventListener('click', () => {
+          // 6) 전부 답했는지 확인
+          const answers = [];
+          if (!childSelect.value) { return alert('자녀를 선택해주세요'); }
+          if (!ageSelect.value)   { return alert('연령대를 선택해주세요'); }
+          if (!targetSelect.value){ return alert('대상 그룹을 선택해주세요'); }
+
+          for (let s of surveys) {
+            const sel = document.querySelector(`input[name="q${s.id}"]:checked`);
+            if (!sel) { return alert('모든 문진에 답변해주세요'); }
+            answers.push(+sel.value);
+          }
+
+          // 7) 제출
+          fetch('/api/group-surveys/submit', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({
+              ageGroup:    ageSelect.value,
+              targetGroup: targetSelect.value,
+              answers:     answers,
+              childId:     Number(childSelect.value),
+            })
+          })
+          .then(r => r.ok ? r.json() : Promise.reject())
+          .then(res => {
+            const payload = encodeURIComponent(JSON.stringify(res));
+            window.location.href = `/groupSurvey/result?data=${payload}`;
+          })
+          .catch(() => alert('제출 중 오류 발생'));
+        });
+    </script>
+</th:block>
+</html>

--- a/src/main/resources/templates/groupSurveyResult.html
+++ b/src/main/resources/templates/groupSurveyResult.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>그룹 문진 결과</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+
+<th:block layout:fragment="content">
+    <div class="max-w-4xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-6">문진 결과</h1>
+
+        <div id="resultContainer" class="space-y-4">
+            <!-- JS가 여기에 카테고리별 점수, 통합 점수를 뿌려줍니다 -->
+        </div>
+
+        <div class="mt-8">
+            <button onclick="location.href='/groupSurvey'"
+                    class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">
+                다시 문진하기
+            </button>
+        </div>
+    </div>
+
+    <script>
+        // 1) URL에서 data 파라미터 뽑아오기
+        const params = new URLSearchParams(window.location.search);
+        const dataParam = params.get("data");
+        let result;
+        try {
+          // encodeURIComponent 로 넘겼으니 decode 한 뒤 JSON.parse
+          result = JSON.parse(decodeURIComponent(dataParam));
+        } catch (e) {
+          console.error("결과 파싱 실패", e);
+          document.getElementById("resultContainer")
+                  .innerHTML = `<p class="text-red-500">결과를 불러오는 데 실패했습니다.</p>`;
+          throw e;
+        }
+
+        const { categoryScores, totalRiskScore } = result;
+        const container = document.getElementById("resultContainer");
+
+        // 2) 카테고리별 점수
+        for (const [cat, score] of Object.entries(categoryScores)) {
+          const div = document.createElement("div");
+          div.className = "p-4 border rounded bg-gray-50";
+          div.innerHTML = `
+            <p class="font-semibold">${cat} 위험도: ${score.toFixed(2)}%</p>
+          `;
+          container.appendChild(div);
+        }
+
+        // 3) 통합 위험도 (문진 항목 수에 따라 나눌 수도 있고, 그대로 보여도 좋습니다)
+        const overallDiv = document.createElement("div");
+        overallDiv.className = "mt-4 p-4 border rounded bg-blue-50";
+        overallDiv.innerHTML = `
+          <p class="font-bold text-lg">통합 위험도: ${totalRiskScore.toFixed(2)}</p>
+        `;
+        container.appendChild(overallDiv);
+    </script>
+</th:block>
+</html>

--- a/src/main/resources/templates/specialSurvey.html
+++ b/src/main/resources/templates/specialSurvey.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>특별 문진</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<th:block layout:fragment="content">
+    <div class="max-w-4xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-6">특별 문진</h1>
+
+        <!-- 1) 자녀 선택 -->
+        <div class="mb-4">
+            <label class="block mb-1 font-semibold">자녀 선택</label>
+               <select id="childSelect" class="border p-2 rounded w-64">
+                   <option value="">-- 자녀를 선택하세요 --</option>
+                   <option th:each="c : ${children}"
+                             th:value="${c.id}"
+                             th:text="${c.name + ' (' + c.nickname + ')'}">
+                   </option>
+               </select>
+        </div>
+
+        <!-- 2) 연령대 선택 -->
+        <div class="mb-4">
+            <label class="block mb-1 font-semibold">연령대</label>
+               <select id="ageSelect" class="border p-2 rounded w-64">
+                   <option value="">-- 연령대를 선택하세요 --</option>
+                   <option th:each="ag : ${ageGroups}"
+                             th:value="${ag.name()}"
+                             th:text="${ag.displayName}">
+                   </option>
+               </select>
+        </div>
+
+        <!-- 3) 카테고리 선택 -->
+        <div class="mb-4">
+            <label class="block mb-1 font-semibold">카테고리</label>
+               <select id="categorySelect" class="border p-2 rounded w-64">
+                   <option value="">-- 카테고리를 선택하세요 --</option>
+                   <option th:each="cat : ${categories}"
+                             th:value="${cat.name()}"
+                             th:text="${cat.displayName}">
+                   </option>
+               </select>
+        </div>
+
+        <!-- 4) 문진 출력 영역 -->
+        <div id="surveyContainer" class="mb-6 space-y-4"></div>
+
+        <!-- 5) 제출 버튼 -->
+        <button id="submitBtn"
+                class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">
+            제출하기
+        </button>
+    </div>
+
+    <script>
+        const childSelect   = document.getElementById('childSelect');
+        const ageSelect     = document.getElementById('ageSelect');
+        const catSelect     = document.getElementById('categorySelect');
+        const container     = document.getElementById('surveyContainer');
+        const submitBtn     = document.getElementById('submitBtn');
+        let surveys = [];
+
+        function loadSurveys() {
+          const age = ageSelect.value;
+          if (!age) { container.innerHTML = ''; return; }
+
+          fetch(`/api/special-surveys/by-age/${encodeURIComponent(age)}`)
+            .then(r => r.ok ? r.json() : Promise.reject())
+            .then(data => {
+              // 카테고리 필터링
+              const cat = catSelect.value;
+              surveys = cat
+                ? data.filter(s => s.category === document.querySelector('#categorySelect option:checked').text)
+                : data;
+              renderSurveys();
+            })
+            .catch(() => alert('문진 데이터를 불러오는 중 오류 발생'));
+        }
+
+        ageSelect.addEventListener('change', loadSurveys);
+        catSelect .addEventListener('change', loadSurveys);
+
+        function renderSurveys() {
+          container.innerHTML = '';
+          surveys.forEach((s,i) => {
+            const div = document.createElement('div');
+            div.className = 'border p-4 rounded';
+            div.innerHTML = `
+              <p class="font-semibold mb-2">Q${i+1}. ${s.question}
+                <span class="text-sm text-gray-500">(${s.category})</span>
+              </p>
+              ${[1,2,3,4,5].map(v =>
+                `<label class="block">
+                   <input type="radio" name="q${s.id}" value="${v}"> ${s['answer'+v]}
+                 </label>`
+              ).join('')}
+            `;
+            container.appendChild(div);
+          });
+        }
+
+        submitBtn.addEventListener('click', () => {
+          const answers = [];
+          if (!childSelect.value) return alert('자녀를 선택해주세요');
+          if (!ageSelect.value)   return alert('연령대를 선택해주세요');
+          if (!catSelect.value)   return alert('카테고리를 선택해주세요');
+
+          for (let s of surveys) {
+            const sel = document.querySelector(`input[name="q${s.id}"]:checked`);
+            if (!sel) return alert('모든 문진에 답변해주세요');
+            answers.push(+sel.value);
+          }
+
+          fetch('/api/special-surveys/submit', {
+            method: 'POST',
+            headers: { 'Content-Type':'application/json' },
+            body: JSON.stringify({
+              childId:   Number(childSelect.value),
+              ageGroup:  ageSelect.value,
+              category:  catSelect.value,
+              answers:   answers
+            })
+          })
+          .then(r => r.ok ? r.json() : Promise.reject())
+          .then(res => {
+            const payload = encodeURIComponent(JSON.stringify(res));
+            window.location.href = `/specialSurvey/result?data=${payload}`;
+          })
+          .catch(() => alert('제출 중 오류 발생'));
+        });
+    </script>
+</th:block>
+</html>

--- a/src/main/resources/templates/specialSurveyResult.html
+++ b/src/main/resources/templates/specialSurveyResult.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>특별 문진 결과</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<th:block layout:fragment="content">
+    <div class="max-w-4xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-6">문진 결과</h1>
+        <div id="resultContainer" class="space-y-4"></div>
+        <div class="mt-8">
+            <button onclick="location.href='/specialSurvey'"
+                    class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">
+                다시 문진하기
+            </button>
+        </div>
+    </div>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const dataParam = params.get("data");
+        let result;
+        try {
+          result = JSON.parse(decodeURIComponent(dataParam));
+        } catch {
+          document.getElementById("resultContainer")
+            .innerHTML = `<p class="text-red-500">결과를 불러오는 데 실패했습니다.</p>`;
+          throw Error();
+        }
+        const { categoryScores, totalRiskScore } = result;
+        const container = document.getElementById("resultContainer");
+
+        Object.entries(categoryScores).forEach(([cat,score]) => {
+          const div = document.createElement("div");
+          div.className = "p-4 border rounded bg-gray-50";
+          div.innerHTML = `<p class="font-semibold">${cat} 위험도: ${score.toFixed(2)}%</p>`;
+          container.appendChild(div);
+        });
+        const overall = document.createElement("div");
+        overall.className = "mt-4 p-4 border rounded bg-blue-50";
+        overall.innerHTML = `<p class="font-bold text-lg">통합 위험도: ${totalRiskScore.toFixed(2)}</p>`;
+        container.appendChild(overall);
+    </script>
+</th:block>
+</html>

--- a/src/main/resources/templates/survey/dailyAnswerHistory.html
+++ b/src/main/resources/templates/survey/dailyAnswerHistory.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>데일리 문진 이력</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<th:block layout:fragment="content">
+    <div class="max-w-4xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-6">데일리 문진 답변 이력</h1>
+
+        <!-- 1) 자녀 선택 -->
+        <div class="mb-6">
+            <label for="childSelect" class="font-semibold mr-2">자녀 선택:</label>
+            <select id="childSelect" class="border p-2 rounded w-64">
+                <option value="" disabled selected>자녀를 선택하세요</option>
+                <option th:each="c : ${children}"
+                        th:value="${c.id}"
+                        th:text="${c.name + ' ('+c.nickname+')'}">
+                </option>
+            </select>
+        </div>
+
+        <!-- 2) 자녀 정보 -->
+        <div id="childInfo" class="mb-6 p-4 border rounded bg-gray-50 hidden">
+            <h2 class="text-lg font-semibold mb-2">자녀 정보</h2>
+            <p><strong>이름:</strong> <span id="infoName"></span></p>
+            <p><strong>성별:</strong> <span id="infoGender"></span></p>
+            <p><strong>나이:</strong> <span id="infoAge"></span></p>
+            <p><strong>키:</strong> <span id="infoHeight"></span></p>
+            <p><strong>체중:</strong> <span id="infoWeight"></span></p>
+        </div>
+
+        <!-- 3) 답변 이력 리스트 -->
+        <div id="answerList" class="space-y-4"></div>
+    </div>
+
+    <!-- 4) 수정 모달 -->
+    <div id="editModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+        <div class="bg-white p-6 rounded shadow-xl w-full max-w-lg">
+            <h2 class="text-xl font-bold mb-4">답변 수정</h2>
+            <div id="modalOptions" class="space-y-2 mb-4"></div>
+            <div class="flex justify-end gap-4">
+                <button id="cancelEdit" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">취소</button>
+                <button id="saveEdit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">저장</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let lastFetchedHistory = [];
+
+        document.addEventListener("DOMContentLoaded", () => {
+          const childSelect = document.getElementById("childSelect");
+          const answerList  = document.getElementById("answerList");
+          const childInfo   = document.getElementById("childInfo");
+          const infoName    = document.getElementById("infoName");
+          const infoGender  = document.getElementById("infoGender");
+          const infoAge     = document.getElementById("infoAge");
+          const infoHeight  = document.getElementById("infoHeight");
+          const infoWeight  = document.getElementById("infoWeight");
+
+          const editModal    = document.getElementById("editModal");
+          const modalTextarea= document.getElementById("modalTextarea");
+          const cancelEdit   = document.getElementById("cancelEdit");
+          const saveEdit     = document.getElementById("saveEdit");
+          let currentEditId  = null;
+
+          childSelect.addEventListener("change", () => {
+            const childId = childSelect.value;
+            if (!childId) return;
+
+            // 자녀 정보 조회 (필요 시 ChildController 에 API 추가)
+            fetch(`/api/child/info/${childId}`)
+              .then(res => res.json())
+              .then(data => {
+                childInfo.classList.remove("hidden");
+                infoName.textContent   = data.name;
+                infoGender.textContent = data.gender;
+                infoAge.textContent    = data.age + '세';
+                infoHeight.textContent = data.height;
+                infoWeight.textContent = data.weight;
+              });
+
+            // 답변 이력 조회
+            fetch(`/dailyAnswer/api/history/${childId}`)
+              .then(res => res.json())
+              .then(data => {
+                lastFetchedHistory = data;
+                answerList.innerHTML = "";
+                if (data.length === 0) {
+                  answerList.innerHTML = `<p class="text-gray-500">답변 이력이 없습니다.</p>`;
+                  return;
+                }
+                // 날짜별 그룹핑
+                const grouped = {};
+                data.forEach(item => {
+                  const date = item.createdAt.substring(0,10);
+                  grouped[date] = grouped[date] || [];
+                  grouped[date].push(item);
+                });
+                Object.keys(grouped)
+                  .sort((a,b) => new Date(b) - new Date(a))
+                  .forEach(date => {
+                    const container = document.createElement("div");
+                    container.className = "border rounded mb-4";
+
+                    const header = document.createElement("button");
+                    header.type = "button";
+                    header.className = "w-full text-left px-4 py-2 bg-blue-100 font-semibold hover:bg-blue-200";
+                    header.textContent = `${date} 문진 답변`;
+
+                    const body = document.createElement("div");
+                    body.className = "hidden p-4 space-y-4 bg-gray-50";
+
+                    grouped[date].forEach((ans, idx) => {
+                      const item = document.createElement("div");
+                      item.className = "border p-3 rounded";
+                      item.innerHTML = `
+                        <div class="flex justify-between">
+                          <div class="w-full">
+                            <p class="font-semibold">
+                              ${idx+1}. [${ans.category} | ${ans.ageGroup}] ${ans.question}
+                            </p>
+                            <p class="text-sm text-gray-700 whitespace-pre-line"
+                               id="answerText_${ans.id}">
+                              ${ans.answer}
+                            </p>
+                            <p class="text-xs text-gray-500">가중치: ${ans.weight}</p>
+                          </div>
+                          <div class="flex flex-col items-end gap-2 ml-4">
+                            <button onclick="showEditModal(${ans.id})"
+                                    class="text-blue-600 hover:underline text-sm">수정</button>
+                            <button onclick="deleteAnswer(${ans.id})"
+                                    class="text-red-600 hover:underline text-sm">삭제</button>
+                          </div>
+                        </div>`;
+                      body.appendChild(item);
+                    });
+
+                    header.addEventListener("click", () => body.classList.toggle("hidden"));
+                    container.appendChild(header);
+                    container.appendChild(body);
+                    answerList.appendChild(container);
+                  });
+              })
+              .catch(() => {
+                answerList.innerHTML = `<p class="text-red-500">답변을 불러오는 중 오류가 발생했습니다.</p>`;
+              });
+          });
+
+          window.deleteAnswer = (id) => {
+            if (!confirm("정말 삭제하시겠습니까?")) return;
+            fetch(`/dailyAnswer/api/answer/${id}`, { method: "DELETE" })
+              .then(r => {
+                if (r.ok) {
+                  alert("삭제되었습니다.");
+                  childSelect.dispatchEvent(new Event("change"));
+                } else {
+                  alert("삭제 중 오류가 발생했습니다.");
+                }
+              });
+          };
+        window.showEditModal = (id) => {
+          currentEditId = id;
+          // 전역 변수에서 해당 객체 찾기
+          const ansObj = lastFetchedHistory.find(a => a.id === id);
+          if (!ansObj) return alert("답변 데이터를 찾을 수 없습니다.");
+
+          // options 렌더링
+          modalOptions.innerHTML = "";
+          ansObj.possibleAnswers.forEach((text, idx) => {
+            const value = idx + 1;
+            const label = document.createElement("label");
+            label.className = "flex items-center gap-2";
+            label.innerHTML = `
+              <input type="radio" name="editAnswer" value="${value}"
+                ${value === ansObj.selectedValue ? "checked" : ""}/>
+              ${text}
+            `;
+            modalOptions.appendChild(label);
+          });
+
+          editModal.classList.remove("hidden");
+        };
+
+        cancelEdit.addEventListener("click", () => {
+          editModal.classList.add("hidden");
+          currentEditId = null;
+        });
+
+            saveEdit.addEventListener("click", () => {
+              const checked = document.querySelector('input[name="editAnswer"]:checked');
+              if (!checked) {
+                alert("답변을 선택해주세요.");
+                return;
+              }
+
+              fetch(`/dailyAnswer/api/answer/${currentEditId}`, {
+                method: "PUT",
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  answerValue: parseInt(checked.value, 10)   // <-- key 가 DTO 와 꼭 일치해야 합니다.
+                })
+              })
+              .then(r => {
+                if (r.ok) {
+                  alert("수정되었습니다.");
+                  editModal.classList.add("hidden");
+                  childSelect.dispatchEvent(new Event("change"));
+                } else {
+                  alert("수정 중 오류가 발생했습니다.");
+                }
+              });
+            });
+        });
+    </script>
+</th:block>
+</html>

--- a/src/main/resources/templates/survey/groupAnswerHistory.html
+++ b/src/main/resources/templates/survey/groupAnswerHistory.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>그룹 문진 이력</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<th:block layout:fragment="content">
+    <div class="max-w-4xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-6">그룹 문진 이력</h1>
+
+        <!-- 1) 자녀 선택 -->
+        <div class="mb-4">
+            <label for="childSelect" class="font-semibold mr-2">자녀 선택:</label>
+            <select id="childSelect" class="border p-2 rounded w-64">
+                <option value="" disabled selected>자녀를 선택하세요</option>
+                <option th:each="c : ${children}"
+                        th:value="${c.id}"
+                        th:text="${c.name + ' (' + c.nickname + ')'}">
+                </option>
+            </select>
+        </div>
+
+        <!-- 2) 이력 리스트 -->
+        <div id="answerList" class="space-y-4"></div>
+    </div>
+
+    <!-- 3) 수정 모달 (Daily 문진과 동일 구조) -->
+    <div id="editModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+        <div class="bg-white p-6 rounded shadow-xl w-full max-w-lg">
+            <h2 class="text-xl font-bold mb-4">답변 수정</h2>
+            <div id="modalOptions" class="space-y-2 mb-4"></div>
+            <div class="flex justify-end gap-4">
+                <button id="cancelEdit" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">취소</button>
+                <button id="saveEdit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">저장</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let lastFetched = [];
+        let currentEditId = null;
+
+        document.getElementById('childSelect').addEventListener('change', () => {
+          const childId = document.getElementById('childSelect').value;
+          const list = document.getElementById('answerList');
+          if (!childId) { list.innerHTML = ''; return; }
+
+          // 이력 조회
+          fetch(`/groupAnswer/api/history/${childId}`)
+            .then(r => r.json())
+            .then(data => {
+              lastFetched = data;
+              list.innerHTML = '';
+              if (data.length === 0) {
+                list.innerHTML = `<p class="text-gray-500">답변 이력이 없습니다.</p>`;
+                return;
+              }
+
+              // 날짜별 그룹핑
+              const byDate = {};
+              data.forEach(a => {
+                const d = a.createdAt.substring(0,10);
+                (byDate[d] = byDate[d]||[]).push(a);
+              });
+
+              // 렌더링
+              Object.keys(byDate)
+                .sort((a,b) => new Date(b) - new Date(a))
+                .forEach(date => {
+                  const section = document.createElement('div');
+                  section.className = 'border rounded mb-4';
+
+                  const header = document.createElement('button');
+                  header.type = 'button';
+                  header.className = 'w-full text-left px-4 py-2 bg-blue-100 font-semibold hover:bg-blue-200';
+                  header.textContent = `${date} 문진 답변`;
+
+                  const body = document.createElement('div');
+                  body.className = 'hidden p-4 space-y-4 bg-gray-50';
+
+                  byDate[date].forEach((ans,i) => {
+                    const card = document.createElement('div');
+                    card.className = 'border p-3 rounded flex justify-between';
+
+                    card.innerHTML = `
+                      <div>
+                        <p class="font-semibold">
+                          ${i+1}. [${ans.targetGroup} | ${ans.category}] ${ans.question}
+                        </p>
+                        <p class="text-sm text-gray-700 whitespace-pre-line" id="answerText_${ans.id}">
+                          ${ans.answer}
+                        </p>
+                        <p class="text-xs text-gray-500">가중치: ${ans.weight}</p>
+                      </div>
+                      <div class="flex flex-col gap-2 justify-center">
+                        <button onclick="showEditModal(${ans.id})"
+                                class="text-blue-600 hover:underline text-sm">수정</button>
+                        <button onclick="deleteAnswer(${ans.id})"
+                                class="text-red-600 hover:underline text-sm">삭제</button>
+                      </div>
+                    `;
+                    body.appendChild(card);
+                  });
+
+                  header.addEventListener('click', () => body.classList.toggle('hidden'));
+                  section.append(header, body);
+                  list.append(section);
+                });
+            });
+        });
+
+        function deleteAnswer(id) {
+          if (!confirm('정말 삭제하시겠습니까?')) return;
+          fetch(`/groupAnswer/api/answer/${id}`, { method: 'DELETE' })
+            .then(r => {
+              if (r.ok) document.getElementById('childSelect').dispatchEvent(new Event('change'));
+              else alert('삭제 중 오류 발생');
+            });
+        }
+
+        function showEditModal(id) {
+          currentEditId = id;
+          const dto = lastFetched.find(a => a.id === id);
+          const opts = document.getElementById('modalOptions');
+          opts.innerHTML = '';
+          dto.possibleAnswers.forEach((text, i) => {
+            const v = i + 1;
+            opts.insertAdjacentHTML("beforeend", `
+              <label class="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="editAnswer"
+                  value="${v}"
+                  ${v === dto.selectedValue ? "checked" : ""}  <!-- () 없앰 -->
+                ${text}
+              </label>
+            `);
+          });
+
+          document.getElementById("editModal").classList.remove("hidden");
+        }
+
+        document.getElementById('cancelEdit').addEventListener('click', () => {
+          document.getElementById('editModal').classList.add('hidden');
+        });
+
+        document.getElementById('saveEdit').addEventListener('click', () => {
+          const sel = document.querySelector('input[name="editAnswer"]:checked');
+          if (!sel) return alert('답변을 선택해주세요.');
+          fetch(`/groupAnswer/api/answer/${currentEditId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type':'application/json' },
+            body: JSON.stringify({ answerValue: +sel.value })
+          })
+          .then(r => {
+            if (r.ok) {
+              alert('수정되었습니다.');
+              document.getElementById('editModal').classList.add('hidden');
+              document.getElementById('childSelect').dispatchEvent(new Event('change'));
+            } else {
+              alert('수정 중 오류 발생');
+            }
+          });
+        });
+    </script>
+</th:block>
+</html>

--- a/src/main/resources/templates/survey/specialAnswerHistory.html
+++ b/src/main/resources/templates/survey/specialAnswerHistory.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>특별 문진 이력</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<th:block layout:fragment="content">
+    <div class="max-w-4xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-6">특별 문진 이력</h1>
+
+        <!-- 자녀 선택 -->
+        <div class="mb-4">
+            <label class="font-semibold">자녀:</label>
+            <select id="childSelect" class="border p-2 rounded w-64">
+                <option value="" disabled selected>자녀를 선택하세요</option>
+                <option th:each="c : ${children}"
+                        th:value="${c.id}"
+                        th:text="${c.name + ' (' + c.nickname + ')'}"/>
+            </select>
+        </div>
+
+        <!-- 이력 리스트 -->
+        <div id="answerList" class="space-y-4"></div>
+    </div>
+
+    <!-- 수정 모달 (Daily와 동일) -->
+    <div id="editModal"
+         class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+        <div class="bg-white p-6 rounded shadow-xl w-full max-w-lg">
+            <h2 class="text-xl font-bold mb-4">답변 수정</h2>
+            <div id="modalOptions" class="space-y-2 mb-4"></div>
+            <div class="flex justify-end gap-4">
+                <button id="cancelEdit"
+                        class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">취소</button>
+                <button id="saveEdit"
+                        class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">저장</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let historyData = [];
+        let currentId   = null;
+
+        document.getElementById('childSelect').addEventListener('change', () => {
+          const childId = +document.getElementById('childSelect').value;
+          const list    = document.getElementById('answerList');
+          if (!childId) { list.innerHTML = ''; return; }
+
+          fetch(`/specialAnswer/api/history/${childId}`)
+            .then(r => r.json())
+            .then(data => {
+              historyData = data;
+              list.innerHTML = data.length
+                ? renderHistory(data)
+                : `<p class="text-gray-500">답변 이력이 없습니다.</p>`;
+            });
+        });
+
+        function renderHistory(data) {
+          const byDate = data.reduce((acc,a) => {
+            const d = a.createdAt.substring(0,10);
+            (acc[d] = acc[d]||[]).push(a);
+            return acc;
+          }, {});
+          let html = '';
+          Object.keys(byDate)
+            .sort((a,b)=>new Date(b)-new Date(a))
+            .forEach(date => {
+              html += `<div class="border rounded mb-4">
+                         <button class="w-full text-left px-4 py-2 bg-blue-100 font-semibold">
+                           ${date} 문진 답변
+                         </button>
+                         <div class="hidden p-4 space-y-4 bg-gray-50">`;
+              byDate[date].forEach((ans,i) => {
+                html += `<div class="flex justify-between border p-3 rounded">
+                           <div>
+                             <p class="font-semibold">
+                               ${i+1}. [${ans.category}] ${ans.question}
+                             </p>
+                             <p class="text-sm text-gray-700" id="answerText_${ans.id}">
+                               ${ans.answer}
+                             </p>
+                             <p class="text-xs text-gray-500">가중치: ${ans.weight}</p>
+                           </div>
+                           <div class="flex flex-col gap-2 justify-center">
+                             <button onclick="openEdit(${ans.id})"
+                                     class="text-blue-600 hover:underline text-sm">수정</button>
+                             <button onclick="deleteAns(${ans.id})"
+                                     class="text-red-600 hover:underline text-sm">삭제</button>
+                           </div>
+                         </div>`;
+              });
+              html += `  </div>
+                       </div>`;
+            });
+          return html;
+        }
+
+        function deleteAns(id) {
+          if (!confirm('정말 삭제하시겠습니까?')) return;
+          fetch(`/specialAnswer/api/answer/${id}`, { method:'DELETE' })
+            .then(r=> r.ok && document.getElementById('childSelect').dispatchEvent(new Event('change')));
+        }
+
+        function openEdit(id) {
+          currentId = id;
+          const dto = historyData.find(a=>a.id===id);
+          const opts = document.getElementById('modalOptions');
+          opts.innerHTML = '';
+          dto.possibleAnswers.forEach((txt,i) => {
+            const v = i+1;
+            opts.insertAdjacentHTML('beforeend', `
+              <label class="flex items-center gap-2">
+                <input type="radio" name="editAnswer" value="${v}"
+                  ${dto.selectedValue === v ? 'checked' : ''}/>
+                ${txt}
+              </label>`);
+          });
+          document.getElementById('editModal').classList.remove('hidden');
+        }
+
+        document.getElementById('cancelEdit').onclick = () =>
+          document.getElementById('editModal').classList.add('hidden');
+
+        document.getElementById('saveEdit').onclick = () => {
+          const sel = +document.querySelector('input[name="editAnswer"]:checked')?.value;
+          if (!sel) return alert('답변을 선택해주세요');
+          fetch(`/specialAnswer/api/answer/${currentId}`, {
+            method:'PUT',
+            headers:{ 'Content-Type':'application/json' },
+            body: JSON.stringify({ answerValue: sel })
+          })
+          .then(r=>{
+            if (r.ok) {
+              alert('수정되었습니다.');
+              document.getElementById('editModal').classList.add('hidden');
+              document.getElementById('childSelect').dispatchEvent(new Event('change'));
+            }
+          });
+        };
+    </script>
+</th:block>
+</html>


### PR DESCRIPTION
데일리 문진 응답 관련 기능 수정 
그룹 문진 응답 관련 기능 구현

DailyAnswerDto
DailyAnswerPageController
DailyAnswerRepository
- 데일리 문진 응답 이력 페이지 기능 고도화
- 데일리 문진 응답 이력 아코디언 구조
- 데일리 문진 응답 수정/삭제 기능 구현

GroupSurvey
Converter가 자동 매핑 해주므로 @Convert 제거

GroupSurveyController
- 그룹 응답 기능 서비스 추가
- dto로 저장

GroupSurveyRequestDto
- setId는 필요 없으므로 제거
- 자녀와 연결되어야하므로 childId 추가

GroupSurveyService
- 연령대, 대상그룹 필터기능 추가

TargetGroup
- 통합 그룹은 필요 없으므로 제거

AnswerUpdateRequest
- 데일리나 특별, 그룹 문진은 체크박스 벨류로 수정하므로 필요한 dto

dailyAnswerHistory
- 데일리 문진 응답 조회 페이지 변경
- 수정, 삭제 기능 추가

DailyAnswerRequest
- 체크박스 값 전달 Dto

DailyAnswerService
- 데일리 응답 관련 서비스

GroupAnswer 엔티티 생성
GroupAnswerController
- 그룹 문진 자녀의 답변 조회, 수정, 삭제 기능

GroupSurveyPageController
- 페이지 관련 컨트롤러
- 로그인한 사용자의 페이지 출력

GroupAnswerDto
- 이력 api 응답용 dto

html
groupSurvey
- 문진 페이지 groupSurveyResult
- 문진 결과 페이지 groupAnswerHistory
- 문진 응답 이력 조회 페이지

Special쪽은 아직 하는 중..
다음에 완성 후 설명