### PR TITLE
feat: 그룹 문진 세트 알림 발송 기능 구현 

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
 rootProject.name = 'charti'

--- a/src/main/java/com/example/demo/exception/SurveySetNotFoundException.java
+++ b/src/main/java/com/example/demo/exception/SurveySetNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.demo.exception;
+
+public class SurveySetNotFoundException extends RuntimeException {
+  public SurveySetNotFoundException() {
+    super("해당 문진 세트가 존재하지 않습니다.");
+  }
+}

--- a/src/main/java/com/example/demo/fcm/controller/ManagerNotificationController.java
+++ b/src/main/java/com/example/demo/fcm/controller/ManagerNotificationController.java
@@ -1,0 +1,62 @@
+package com.example.demo.fcm.controller;
+
+
+import com.example.demo.dto.UserDTO;
+import com.example.demo.fcm.service.FcmService;
+import com.example.demo.survey.entity.SurveySet;
+import com.example.demo.survey.service.SurveySetService;
+import com.example.demo.users.service.AuthService;
+import com.example.demo.users.service.ManagerService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/manager/notification")
+@RequiredArgsConstructor
+@Slf4j
+public class ManagerNotificationController {
+
+    private final AuthService authService;
+    private final SurveySetService surveySetService;
+    private final FcmService fcmService;
+    private final ManagerService managerService;
+
+    /**
+     * 문진 알림 발송 폼
+     */
+    @GetMapping("/form")
+    public String showNotificationForm(Model model) {
+        UserDTO user = authService.getLoginUser();
+        Long managerId = user.getId();
+
+        List<SurveySet> surveySets = surveySetService.getSetsForManager(managerId); // 담당자에게 배정된 세트만 조회
+        model.addAttribute("surveySets", surveySets);
+        return "manager/notification/notificationForm";
+    }
+
+    /**
+     * 문진 알림 발송 처리
+     */
+    @PostMapping("/send")
+    public String sendNotification(@RequestParam("setId") Long setId,
+                                   Model model,
+                                   HttpServletRequest request) {
+        UserDTO user = authService.getLoginUser();
+
+        try {
+            fcmService.sendSurveySetToGroupMembers(user.getId(), setId); // 해당 담당자의 그룹 구성원에게 전송
+            model.addAttribute("message", "✅ 문진 알림이 성공적으로 발송되었습니다.");
+        } catch (Exception e) {
+            log.error("문진 알림 발송 실패", e);
+            model.addAttribute("message", "❌ 문진 알림 발송 중 오류가 발생했습니다.");
+        }
+
+        return "manager/notification/notificationForm";
+    }
+}

--- a/src/main/java/com/example/demo/fcm/entity/FcmSendHistory.java
+++ b/src/main/java/com/example/demo/fcm/entity/FcmSendHistory.java
@@ -68,4 +68,16 @@ public class FcmSendHistory {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id")
     private Users sender;
+
+    /**
+     * [이동 링크]
+     * 이 알림을 클릭했을 때 이동하게 될 공통 URL.
+     * 예: 특정 문진 세트 응답 페이지 (/survey/set/123 등)
+     *
+     * 수신자 개별 알림(Notice.url)과는 다르게,
+     * 발송 기록 차원에서 '어떤 링크로 안내했는가'를 남기기 위해 사용함.
+     */
+    @Column(name = "link", length = 1024)
+    private String link;
+
 }

--- a/src/main/java/com/example/demo/fcm/repository/FcmSendHistoryRepository.java
+++ b/src/main/java/com/example/demo/fcm/repository/FcmSendHistoryRepository.java
@@ -6,3 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FcmSendHistoryRepository extends JpaRepository<FcmSendHistory, Long> {
     // 기본적인 CRUD 메서드 사용 가능
 }
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.Pageable;
+//import java.time.LocalDateTime;
+//
+//public interface FcmSendHistoryRepository extends JpaRepository<FcmSendHistory, Long> {
+//    // 특정 기간 동안의 발송 이력을 페이징하여 조회
+//    Page<FcmSendHistory> findBySentAtBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
+//
+//    // 특정 카테고리의 발송 이력을 페이징하여 조회
+//    Page<FcmSendHistory> findByCategory(FcmCategory category, Pageable pageable);
+//}

--- a/src/main/java/com/example/demo/fcm/service/FcmService.java
+++ b/src/main/java/com/example/demo/fcm/service/FcmService.java
@@ -10,11 +10,16 @@ import com.example.demo.fcm.entity.UserFcmToken;
 import com.example.demo.fcm.repository.FcmSendHistoryRepository;
 import com.example.demo.fcm.repository.NoticeRepository;
 import com.example.demo.fcm.repository.UserFcmTokenRepository;
+import com.example.demo.survey.entity.SurveySet;
+import com.example.demo.survey.service.SurveySetService;
 import com.example.demo.users.entity.Users;
+import com.example.demo.users.repository.ManagerRepository;
 import com.example.demo.users.repository.UserRepository;
 import com.example.demo.users.entity.Child;
+import com.example.demo.users.entity.Manager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -22,29 +27,29 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class FcmService {
 
-    private final UserRepository userRepo;
+    private final UserRepository userRepository;
     private final UserFcmTokenRepository tokenRepository;
     private final FcmSender fcmSender;
     private final FcmSendHistoryRepository historyRepository;
     private final NoticeRepository noticeRepository;
+    private final ManagerRepository managerRepository;
+    private final SurveySetService surveySetService;
+    private final FirebaseMessagingService firebaseMessagingService;
 
     /**
      * 조건에 맞는 사용자들에게 FCM 알림을 발송하고, 발송 이력을 기록한다.
      *
-     * @param title      알림 제목
-     * @param body       알림 본문
-     * @param category   알림 카테고리 (DAILY, SPECIAL 등)
-     * @param ageGroup   수신 대상 자녀의 연령대 (null이면 전체 대상)
+     * @param title    알림 제목
+     * @param body     알림 본문
+     * @param category 알림 카테고리 (DAILY, SPECIAL 등)
+     * @param ageGroup 수신 대상 자녀의 연령대 (null이면 전체 대상)
      * @return 성공적으로 알림을 수신한 사용자 수
      */
     @Transactional
-    public int sendNotificationToTarget(String title,
-                                        String body,
-                                        FcmCategory category,
-                                        AgeGroup ageGroup) {
-
+    public int sendNotificationToTarget(String title, String body, FcmCategory category, AgeGroup ageGroup) {
         List<UserFcmToken> targets = tokenRepository.findAll().stream()
                 .filter(token -> !token.getUser().isDeleted())
                 .filter(token -> ageGroup == null || (
@@ -57,24 +62,22 @@ public class FcmService {
         int successCount = 0;
         LocalDateTime now = LocalDateTime.now();
 
-        for (UserFcmToken target : targets) {
-            boolean sent = fcmSender.send(target.getFcmToken(), title, body);
+        for (UserFcmToken token : targets) {
+            boolean sent = fcmSender.send(token.getFcmToken(), title, body);
             if (sent) {
                 successCount++;
-
-                // ── 여기서 Notice 저장 ──
-                Notice notice = Notice.builder()
-                        .user(target.getUser())
-                        .title(title)
-                        .body(body)
-                        .category(category != null ? category : FcmCategory.NOTICE)
-                        .sentAt(now)
-                        .build();
-                noticeRepository.save(notice);
+                noticeRepository.save(
+                        Notice.builder()
+                                .user(token.getUser())
+                                .title(title)
+                                .body(body)
+                                .category(category != null ? category : FcmCategory.NOTICE)
+                                .sentAt(now)
+                                .build()
+                );
             }
         }
 
-        // 발송 이력 저장
         historyRepository.save(
                 FcmSendHistory.builder()
                         .title(title)
@@ -94,18 +97,11 @@ public class FcmService {
      * 특정 사용자에게만 FCM + Notice + SendHistory 저장
      */
     @Transactional
-    public int sendNotificationToUser(Users user,
-                                      String title,
-                                      String body,
-                                      FcmCategory category,
-                                      String url) {
-        // 1) 해당 유저의 활성화된 토큰만 조회
+    public int sendNotificationToUser(Users user, String title, String body, FcmCategory category, String url) {
         List<UserFcmToken> tokens = tokenRepository.findByUserAndIsActiveTrue(user);
-
         int successCount = 0;
         LocalDateTime now = LocalDateTime.now();
 
-        // 2) FCM 발송 & Notice 저장
         for (UserFcmToken token : tokens) {
             boolean sent = fcmSender.send(token.getFcmToken(), title, body);
             if (sent) {
@@ -123,7 +119,6 @@ public class FcmService {
             }
         }
 
-        // 3) SendHistory 저장 (사용자별 기록)
         historyRepository.save(
                 FcmSendHistory.builder()
                         .title(title)
@@ -145,12 +140,11 @@ public class FcmService {
         int successCount = 0;
         int targetCount = 0;
 
-        for (Users user : userRepo.findAll()) {
+        for (Users user : userRepository.findAll()) {
             if (user.getMember() == null) continue;
 
             for (Child child : user.getMember().getChildren()) {
                 if (Boolean.TRUE.equals(child.getRiskGroup())) {
-                    // 이 유저의 활성 토큰 조회
                     for (UserFcmToken token : tokenRepository.findByUserAndIsActiveTrue(user)) {
                         targetCount++;
                         boolean sent = fcmSender.send(
@@ -160,7 +154,6 @@ public class FcmService {
                         );
                         if (sent) {
                             successCount++;
-                            // Notice 저장
                             noticeRepository.save(
                                     Notice.builder()
                                             .user(user)
@@ -168,7 +161,7 @@ public class FcmService {
                                             .body("지금 바로 특별 문진을 완료해주세요..")
                                             .category(FcmCategory.SPECIAL)
                                             .sentAt(now)
-                                            .url("http://localhost:8080/specialSurvey?childId=" + child.getId())
+                                            .url("https://charti.site/specialSurvey?childId=" + child.getId())
                                             .build()
                             );
                         }
@@ -177,7 +170,6 @@ public class FcmService {
             }
         }
 
-        // 발송 이력 저장
         historyRepository.save(
                 FcmSendHistory.builder()
                         .title("위험군 속한 자녀 대상")
@@ -195,6 +187,7 @@ public class FcmService {
 
     /**
      * 그룹(targetGroup) 문진 알림.
+     *
      * @param targetGroup Group.targetGroup 필드값 (e.g. "유치원")
      */
     @Transactional
@@ -202,14 +195,12 @@ public class FcmService {
         LocalDateTime now = LocalDateTime.now();
         int successCount = 0, targetCount = 0;
 
-        for (Users user : userRepo.findAll()) {
+        for (Users user : userRepository.findAll()) {
             if (user.getMember() == null) continue;
-            for (Child child : user.getMember().getChildren()) {
-                if (child.getGroup() != null
-                        && child.getGroup().getTargetGroup() == targetGroup) {
 
-                    for (UserFcmToken token :
-                            tokenRepository.findByUserAndIsActiveTrue(user)) {
+            for (Child child : user.getMember().getChildren()) {
+                if (child.getGroup() != null && child.getGroup().getTargetGroup() == targetGroup) {
+                    for (UserFcmToken token : tokenRepository.findByUserAndIsActiveTrue(user)) {
                         targetCount++;
                         boolean sent = fcmSender.send(
                                 token.getFcmToken(),
@@ -230,8 +221,7 @@ public class FcmService {
                                             .body("지금 바로 그룹 문진을 완료해주세요..")
                                             .category(FcmCategory.SPECIAL)
                                             .sentAt(now)
-                                            .url("http://localhost:8080/groupSurvey?childId="
-                                                    + child.getId())
+                                            .url("https://charti.site/groupSurvey?childId=" + child.getId())
                                             .build()
                             );
                         }
@@ -252,6 +242,76 @@ public class FcmService {
                         .build()
         );
         return successCount;
+    }
+
+    /**
+     * [담당자 → 소속 그룹의 유저들에게 문진 세트 알림 전송]
+     *
+     * @param managerId 로그인한 담당자 ID
+     * @param setId     발송할 문진 세트 ID
+     */
+    @Transactional
+    public void sendSurveySetToGroupMembers(Long managerId, Long setId) {
+        // 1. 문진 세트 및 관리자 정보 조회
+        SurveySet set = surveySetService.getById(setId);
+        String title = "[문진 요청] " + set.getSetTitle();
+        String link = "https://charti.site/survey/set/" + setId;
+
+        Manager manager = managerRepository.findById(managerId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다."));
+        Group group = manager.getGroup();
+
+        // 2. 알림 대상자 조회 (해당 그룹 소속 유저 전체)
+        List<Users> users = userRepository.findAllByManager_Group_Id(group.getId());
+
+        // 3. 히스토리 엔티티 먼저 생성 (알림 1건 기준)
+        FcmSendHistory history = historyRepository.save(
+                FcmSendHistory.builder()
+                        .sender(manager.getUsers()) // 알림 보낸 사람 = 관리자
+                        .title(title)
+                        .body(set.getSetTitle())
+                        .category(FcmCategory.SPECIAL) // 또는 DAILY 등으로 상황에 맞게 지정
+                        .link(link)
+                        .sentAt(LocalDateTime.now())
+                        .targetCount(users.size()) // 전체 대상자 수
+                        .build()
+        );
+
+        // 4. 사용자별 FCM 전송 및 Notice 저장
+        int successCount = 0;
+
+        for (Users user : users) {
+            List<UserFcmToken> tokens = tokenRepository.findByUserAndIsActiveTrue(user);
+            boolean sent = false;
+
+            for (UserFcmToken token : tokens) {
+                try {
+                    firebaseMessagingService.sendMessageToToken(token.getFcmToken(), title, set.getSetTitle(), link);
+                    sent = true;
+                } catch (Exception e) {
+                    log.warn("❌ FCM 발송 실패: userId={}, token={}", user.getId(), token.getFcmToken());
+                }
+            }
+
+            if (sent) {
+                successCount++;
+            }
+
+            // Notice는 항상 저장 (알림함 확인용)
+            noticeRepository.save(
+                    Notice.builder()
+                            .user(user)
+                            .title(title)
+                            .body(set.getSetTitle())
+                            .category(FcmCategory.SPECIAL)
+                            .url(link)
+                            .sentAt(LocalDateTime.now())
+                            .build()
+            );
+        }
+
+        // 5. 성공 개수 반영
+        history.setSuccessCount(successCount);
     }
 
 }

--- a/src/main/java/com/example/demo/fcm/service/FirebaseMessagingService.java
+++ b/src/main/java/com/example/demo/fcm/service/FirebaseMessagingService.java
@@ -1,0 +1,38 @@
+package com.example.demo.fcm.service;
+
+import com.google.firebase.messaging.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class FirebaseMessagingService {
+
+    /**
+     * 단일 FCM 토큰에 메시지 전송
+     *
+     * @param token 수신자 FCM 토큰
+     * @param title 알림 제목
+     * @param body  알림 내용
+     * @param link  클릭 시 이동할 URL
+     */
+    public void sendMessageToToken(String token, String title, String body, String link) {
+        try {
+            Message message = Message.builder()
+                    .setToken(token)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .putData("link", link)
+                    .build();
+
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("✅ FCM 전송 성공: response = {}", response);
+
+        } catch (FirebaseMessagingException e) {
+            log.error("❌ FCM 전송 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("FCM 메시지 전송 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/fcm/service/UserFcmTokenService.java
+++ b/src/main/java/com/example/demo/fcm/service/UserFcmTokenService.java
@@ -28,6 +28,7 @@ public class UserFcmTokenService {
         userFcmTokenRepository.findByFcmToken(request.getFcmToken())
                 .ifPresentOrElse(
                         existing -> {
+                            existing.setUser(user);
                             existing.setLastUsedAt(LocalDateTime.now());
                             existing.setActive(true);
                         },

--- a/src/main/java/com/example/demo/matching/MatchingController.java
+++ b/src/main/java/com/example/demo/matching/MatchingController.java
@@ -73,7 +73,7 @@ public class MatchingController {
         for (SpecialAnswer answer : answers) {
             Matching m = new Matching();
             m.setChild(child);
-            m.setSpecialAnswer(answer);
+//            m.setSpecialAnswer(answer);
             m.setCategory(req.getCategory());
             m.setTitle(req.getTitle());
             m.setContent(req.getContent());

--- a/src/main/java/com/example/demo/matching/entity/Matching.java
+++ b/src/main/java/com/example/demo/matching/entity/Matching.java
@@ -5,9 +5,13 @@ import com.example.demo.enums.MatchingStatus;
 import com.example.demo.enums.SurveyCategory;
 import com.example.demo.survey.entity.SpecialAnswer;
 import com.example.demo.users.entity.Child;
+import com.example.demo.users.entity.Expert;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "matching")
@@ -20,17 +24,20 @@ public class Matching extends BaseEntity {
     private Long id;
 
     // (특별 문진 답변) SpecialAnswer 와 N:1
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "answer_id", nullable = false)
-    private SpecialAnswer specialAnswer;
+    @OneToMany(mappedBy = "matching", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SpecialAnswer> answers = new ArrayList<>();
 
-    // 자녀(Child) 와 N:1
+    // 자녀(Child)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "child_id", nullable = false)
     private Child child;
 
+    // 전문가(Expert)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expert_id")
+    private Expert expert;
+
     // SurveyCategory
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private SurveyCategory category;
 
@@ -42,8 +49,14 @@ public class Matching extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    // 상담 상태 (기본: REQUESTED)
+    // 상담 상태 (기본: 신청완료)
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private MatchingStatus status = MatchingStatus.REQUESTED;
+
+    // 헬퍼 메서드 (양방향 연관관계 설정)
+    public void addAnswer(SpecialAnswer answer) {
+        answers.add(answer);
+        answer.setMatching(this);
+    }
 }

--- a/src/main/java/com/example/demo/survey/controller/GroupAnswerController.java
+++ b/src/main/java/com/example/demo/survey/controller/GroupAnswerController.java
@@ -10,6 +10,7 @@ import com.example.demo.users.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -25,26 +26,71 @@ public class GroupAnswerController {
     private final ChildService childService;
     private final GroupAnswerService answerService;
 
+//    /** 뷰: 이력 페이지 */
+//    @GetMapping("/history")
+//    public String historyPage(Authentication auth, Model model) {
+//        Users me;
+//        try {
+//            me = userService.findByUsernameEntity(auth.getName());
+//        } catch (UserNotFoundException e) {
+//            me = userService.findByUuidEntity(auth.getName());
+//        }
+//        model.addAttribute("children", childService.findByUsersId(me.getId()));
+//        return "survey/groupAnswerHistory";
+//    }
+//
+//    /** API: 특정 자녀의 답변 이력 조회 */
+//    @GetMapping("/api/history/{childId}")
+//    @ResponseBody
+//    public List<GroupAnswerDto> apiHistory(@PathVariable Long childId) {
+//        return answerService.findByChild(childId).stream()
+//                .map(GroupAnswerDto::fromEntity)
+//                .collect(Collectors.toList());
+//    }
+
+    /**
+     * 현재 인증된 사용자의 Users 엔티티를 조회한다.
+     *
+     * @param auth 현재 인증 정보가 담긴 Authentication 객체
+     * @return 인증된 사용자의 Users 엔티티
+     * @throws UserNotFoundException 인증되지 않았거나, 사용자를 찾을 수 없을 경우 발생
+     */
+    private Users getCurrentUser(Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new UserNotFoundException("인증되지 않은 사용자입니다.");
+        }
+
+        String principalIdentifier;
+
+        if (auth.getPrincipal() instanceof UserDetails) {
+            principalIdentifier = ((UserDetails) auth.getPrincipal()).getUsername();
+        } else {
+            principalIdentifier = auth.getName();
+        }
+
+        try {
+            return userService.findByUuidEntity(principalIdentifier);
+        } catch (UserNotFoundException e) {
+            try {
+                return userService.findByUsernameEntity(principalIdentifier);
+            } catch (UserNotFoundException ex) {
+                throw new UserNotFoundException("현재 사용자를 찾을 수 없습니다: " + principalIdentifier);
+            }
+        }
+    }
+
+
     /** 뷰: 이력 페이지 */
     @GetMapping("/history")
     public String historyPage(Authentication auth, Model model) {
-        Users me;
         try {
-            me = userService.findByUsernameEntity(auth.getName());
+            Users me = getCurrentUser(auth); // 헬퍼 메소드 사용
+            model.addAttribute("children", childService.findByUsersId(me.getId()));
+            return "survey/groupAnswerHistory";
         } catch (UserNotFoundException e) {
-            me = userService.findByUuidEntity(auth.getName());
+            // 사용자를 찾지 못하면 로그인 페이지로 리다이렉트
+            return "redirect:/login";
         }
-        model.addAttribute("children", childService.findByUsersId(me.getId()));
-        return "survey/groupAnswerHistory";
-    }
-
-    /** API: 특정 자녀의 답변 이력 조회 */
-    @GetMapping("/api/history/{childId}")
-    @ResponseBody
-    public List<GroupAnswerDto> apiHistory(@PathVariable Long childId) {
-        return answerService.findByChild(childId).stream()
-                .map(GroupAnswerDto::fromEntity)
-                .collect(Collectors.toList());
     }
 
     /** API: 답변 수정 */

--- a/src/main/java/com/example/demo/survey/entity/SpecialAnswer.java
+++ b/src/main/java/com/example/demo/survey/entity/SpecialAnswer.java
@@ -3,6 +3,7 @@ package com.example.demo.survey.entity;
 
 import com.example.demo.entity.BaseEntity;
 import com.example.demo.enums.AgeGroup;
+import com.example.demo.matching.entity.Matching;
 import com.example.demo.users.entity.Child;
 import com.example.demo.enums.TargetGroup;
 import com.example.demo.enums.SurveyCategory;
@@ -19,6 +20,11 @@ public class SpecialAnswer extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "special_answer_id")
     private Long id;
+
+    // --- Matching 과 N:1 (여러 Answer → 하나 Matching) ---
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "matching_id")
+    private Matching matching;
 
     //  특별 문진 항목 (special_survey) 과 N:1
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/demo/survey/repository/SurveySetRepository.java
+++ b/src/main/java/com/example/demo/survey/repository/SurveySetRepository.java
@@ -1,10 +1,14 @@
 package com.example.demo.survey.repository;
 
+import com.example.demo.enums.TargetGroup;
 import com.example.demo.survey.entity.SurveySet;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SurveySetRepository
@@ -19,4 +23,19 @@ public interface SurveySetRepository
     // SPECIAL 세트일 때 specialSurveys만 함께 가져오기
     @EntityGraph(attributePaths = "specialSurveys")
     Optional<SurveySet> findSpecialWithSpecialSurveysBySetId(Long setId);
+
+    /**
+     * [담당자 대상] 특정 TargetGroup(예: 유치원)과 연결된 그룹 문진 세트를 조회
+     *
+     * @param targetGroup 담당자의 그룹 종류 (KINDERGARTEN, DAYCARE 등)
+     * @return 해당 그룹 대상 문진 세트 목록
+     */
+    @Query("""
+    SELECT DISTINCT s FROM SurveySet s
+    JOIN s.groupSurveys gs
+    WHERE s.type = 'GROUP' AND gs.targetGroup = :targetGroup
+""")
+    List<SurveySet> findAllByTargetGroupForManager(@Param("targetGroup") TargetGroup targetGroup);
+
+
 }

--- a/src/main/java/com/example/demo/survey/service/SurveySetService.java
+++ b/src/main/java/com/example/demo/survey/service/SurveySetService.java
@@ -2,10 +2,14 @@ package com.example.demo.survey.service;
 
 import com.example.demo.enums.AgeGroup;
 import com.example.demo.enums.SurveyCategory;
+import com.example.demo.enums.TargetGroup;
 import com.example.demo.survey.dto.SurveySetSearchDto;
 import com.example.demo.survey.dto.SurveySetForm;
 import com.example.demo.survey.entity.*;
 import com.example.demo.survey.repository.*;
+import com.example.demo.users.entity.Manager;
+import com.example.demo.users.repository.ManagerRepository;
+import com.example.demo.users.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +17,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import com.example.demo.exception.SurveySetNotFoundException;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -27,6 +32,7 @@ public class SurveySetService {
     private final SurveySetRepository     surveySetRepo;
     private final GroupSurveyRepository   groupRepo;
     private final SpecialSurveyRepository specialRepo;
+    private final ManagerRepository managerRepo;
 
     /** 목록 + 필터 + 페이징 */
     public Page<SurveySet> list(SurveySetSearchDto dto, Pageable pageable) {
@@ -130,4 +136,30 @@ public class SurveySetService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * [담당자용] 소속 그룹(TargetGroup)에 해당하는 문진 세트 목록 조회
+     *
+     * @param managerId 현재 로그인한 담당자 ID
+     * @return 문진 세트 목록
+     */
+    public List<SurveySet> getSetsForManager(Long managerId) {
+        Manager manager = managerRepo.findById(managerId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다."));
+        TargetGroup targetGroup = manager.getGroup().getTargetGroup();
+
+        return surveySetRepo.findAllByTargetGroupForManager(targetGroup);
+    }
+
+
+    /**
+     * [문진 세트 ID로 단일 조회]
+     *
+     * @param setId 문진 세트 ID
+     * @return SurveySet 엔티티
+     * @throws SurveySetNotFoundException 해당 ID에 해당하는 문진 세트가 없을 경우
+     */
+    public SurveySet getById(Long setId) {
+        return surveySetRepo.findById(setId)
+                .orElseThrow(SurveySetNotFoundException::new);
+    }
 }

--- a/src/main/java/com/example/demo/users/controller/ExpertController.java
+++ b/src/main/java/com/example/demo/users/controller/ExpertController.java
@@ -17,6 +17,7 @@ import com.example.demo.users.exception.UserNotFoundException;
 import com.example.demo.users.repository.ExpertRepository;
 import com.example.demo.users.repository.UserRepository;
 import com.example.demo.users.service.*;
+import com.example.demo.util.AuthStatus;
 import com.example.demo.util.GlobalStatus;
 import com.google.firebase.FirebaseException;
 import com.google.firebase.auth.FirebaseAuthException;

--- a/src/main/java/com/example/demo/users/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/users/repository/UserRepository.java
@@ -43,4 +43,12 @@ public interface UserRepository extends JpaRepository<Users,Long> {
     @Query("UPDATE Users u SET u.role = 'ROLE_MANAGER' WHERE u.id = :id")
     int updateUserRoleToManager(Long id);
 
+    /**
+     * [그룹 ID로 소속 사용자 전체 조회]
+     * 특정 그룹(group_id)에 속한 사용자들을 모두 조회한다.
+     *
+     * @param groupId 그룹 ID
+     * @return 해당 그룹 소속 사용자 리스트
+     */
+    List<Users> findAllByManager_Group_Id(Long groupId);
 }

--- a/src/main/resources/templates/manager/notification/notificationForm.html
+++ b/src/main/resources/templates/manager/notification/notificationForm.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/default_layout}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Charti - 문진 알림 발송</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap"
+          rel="stylesheet">
+    <style> body { font-family: 'Poppins', sans-serif; } </style>
+</head>
+
+<th:block layout:fragment="content">
+    <div class="max-w-2xl mx-auto bg-white shadow p-6 mt-8 rounded">
+        <h1 class="text-2xl font-bold mb-6">📮 문진 세트 알림 발송</h1>
+
+        <form th:action="@{/manager/notification/send}" method="post">
+            <!-- 1) 문진 세트 선택 -->
+            <div class="mb-4">
+                <label for="setId" class="block font-semibold mb-1">문진 세트</label>
+                <select name="setId" id="setId" class="w-full border p-2 rounded" required>
+                    <option value="">세트를 선택해주세요</option>
+                    <option th:each="s : ${surveySets}"
+                            th:value="${s.id}"
+                            th:text="${s.title}"></option>
+                </select>
+            </div>
+
+            <!-- 2) 미리보기 -->
+            <div class="mb-4">
+                <label class="block font-semibold mb-1">알림 미리보기</label>
+                <div class="p-4 border rounded bg-gray-50">
+                    <p class="font-bold" id="preview-title">[제목]</p>
+                    <p id="preview-body" class="text-sm text-gray-700">문진 링크가 포함된 안내 메시지가 여기에 표시됩니다.</p>
+                </div>
+            </div>
+
+            <!-- 3) 제출 -->
+            <button type="submit"
+                    class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700"
+                    onclick="this.disabled=true; this.innerText='발송 중...'; this.form.submit();">
+                문진 알림 발송
+            </button>
+
+        </form>
+
+        <p th:if="${message}" class="mt-6 text-green-600 font-semibold"
+           th:text="${message}"></p>
+    </div>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", () => {
+            const select = document.getElementById("setId");
+            const titleEl = document.getElementById("preview-title");
+            const bodyEl = document.getElementById("preview-body");
+
+            select.addEventListener("change", () => {
+                const selectedTitle = select.options[select.selectedIndex].text;
+                titleEl.textContent = `[문진 알림] ${selectedTitle}`;
+                bodyEl.textContent = `지금 바로 '${selectedTitle}' 문진을 작성해주세요.\n문진 링크는 알림에 포함되어 있습니다.`;
+            });
+        });
+    </script>
+</th:block>
+</html>


### PR DESCRIPTION
- 담당자(manager)가 소속 그룹 유저들에게 특정 문진 세트를 알림으로 발송
- FCM 발송 성공 시 notice 및 발송 이력(fcm_send_history) 저장 처리
- FcmSendHistory 엔티티에 link 필드 추가
- /manager/notification/notificationForm 페이지 구성 및 미리보기 구현
- 알림 수신자는 [문진 바로가기] 버튼 클릭 시 해당 문진 세트 링크로 이동
- 테스트 미진행 / 구현 약 80%