### PR TITLE
0625송성수

### DIFF
--- a/src/main/java/com/example/demo/entity/Group.java
+++ b/src/main/java/com/example/demo/entity/Group.java
@@ -35,6 +35,7 @@ public class Group extends BaseEntity {
     // 그룹 전화번호 회사전화기
     private String groupPhoneNumber;
     // 타겟 그룹(유치원, 어린이집, 보육원)
+    @Column(name = "target_group", nullable = false)
     private TargetGroup targetGroup;
 
     @OneToOne(mappedBy = "group")

--- a/src/main/java/com/example/demo/enums/FcmCategory.java
+++ b/src/main/java/com/example/demo/enums/FcmCategory.java
@@ -3,8 +3,11 @@ package com.example.demo.enums;
 public enum FcmCategory {
     DAILY("데일리문진"),
     SPECIAL("특별문진"),
+    RECORD("기록문진"),
+    GROUP("그룹문진"),
     NOTICE("공지사항"),
     SYSTEM("시스템알림");
+
 
     private final String label;
 

--- a/src/main/java/com/example/demo/fcm/controller/ManagerNotificationController.java
+++ b/src/main/java/com/example/demo/fcm/controller/ManagerNotificationController.java
@@ -25,7 +25,6 @@ public class ManagerNotificationController {
     private final AuthService authService;
     private final SurveySetService surveySetService;
     private final FcmService fcmService;
-    private final ManagerService managerService;
 
     /**
      * 문진 알림 발송 폼
@@ -36,6 +35,7 @@ public class ManagerNotificationController {
         Long managerId = user.getId();
 
         List<SurveySet> surveySets = surveySetService.getSetsForManager(managerId); // 담당자에게 배정된 세트만 조회
+
         model.addAttribute("surveySets", surveySets);
         return "manager/notification/notificationForm";
     }
@@ -44,18 +44,21 @@ public class ManagerNotificationController {
      * 문진 알림 발송 처리
      */
     @PostMapping("/send")
-    public String sendNotification(@RequestParam("setId") Long setId,
-                                   Model model,
-                                   HttpServletRequest request) {
+    public String sendNotification(@RequestParam("setId") Long setId, Model model) {
         UserDTO user = authService.getLoginUser();
+        Long managerId = user.getId();
 
         try {
-            fcmService.sendSurveySetToGroupMembers(user.getId(), setId); // 해당 담당자의 그룹 구성원에게 전송
+            fcmService.sendSurveySetToGroupMembers(managerId, setId);
             model.addAttribute("message", "✅ 문진 알림이 성공적으로 발송되었습니다.");
         } catch (Exception e) {
             log.error("문진 알림 발송 실패", e);
-            model.addAttribute("message", "❌ 문진 알림 발송 중 오류가 발생했습니다.");
+            model.addAttribute("message", "❌ 문진 알림 발송 중 오류가 발생했습니다: " + e.getMessage());
         }
+
+        // 알림 발송 후에도 드롭다운 목록이 유지되도록 세트 목록을 다시 조회해서 모델에 추가
+        List<SurveySet> surveySets = surveySetService.getSetsForManager(managerId);
+        model.addAttribute("surveySets", surveySets);
 
         return "manager/notification/notificationForm";
     }

--- a/src/main/java/com/example/demo/fcm/service/FcmService.java
+++ b/src/main/java/com/example/demo/fcm/service/FcmService.java
@@ -13,6 +13,7 @@ import com.example.demo.fcm.repository.UserFcmTokenRepository;
 import com.example.demo.survey.entity.SurveySet;
 import com.example.demo.survey.service.SurveySetService;
 import com.example.demo.users.entity.Users;
+import com.example.demo.users.repository.ChildRepository;
 import com.example.demo.users.repository.ManagerRepository;
 import com.example.demo.users.repository.UserRepository;
 import com.example.demo.users.entity.Child;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -38,6 +40,7 @@ public class FcmService {
     private final ManagerRepository managerRepository;
     private final SurveySetService surveySetService;
     private final FirebaseMessagingService firebaseMessagingService;
+    private final ChildRepository childRepository;
 
     /**
      * 조건에 맞는 사용자들에게 FCM 알림을 발송하고, 발송 이력을 기록한다.
@@ -245,73 +248,79 @@ public class FcmService {
     }
 
     /**
-     * [담당자 → 소속 그룹의 유저들에게 문진 세트 알림 전송]
+     * 담당자가 소속 그룹의 학부모들에게 '자녀별'로 '문진 세트' 알림을 발송합니다.
      *
-     * @param managerId 로그인한 담당자 ID
-     * @param setId     발송할 문진 세트 ID
+     * @param managerId 알림을 보내는 담당자의 ID
+     * @param setId     발송할 문진 세트의 ID
      */
-    @Transactional
     public void sendSurveySetToGroupMembers(Long managerId, Long setId) {
-        // 1. 문진 세트 및 관리자 정보 조회
-        SurveySet set = surveySetService.getById(setId);
-        String title = "[문진 요청] " + set.getSetTitle();
-        String link = "https://charti.site/survey/set/" + setId;
-
+        // 1. 필요한 정보 조회
         Manager manager = managerRepository.findById(managerId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다."));
-        Group group = manager.getGroup();
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다. ID: " + managerId));
+        SurveySet set = surveySetService.getById(setId);
 
-        // 2. 알림 대상자 조회 (해당 그룹 소속 유저 전체)
-        List<Users> users = userRepository.findAllByManager_Group_Id(group.getId());
+        // 2. 알림 대상 '자녀' 목록 조회
+        List<Child> targetChildren = childRepository.findByGroupId(manager.getGroup().getId());
+        if (targetChildren.isEmpty()) {
+            log.info("그룹 ID {} 에 해당하는 자녀가 없어 알림을 발송하지 않습니다.", manager.getGroup().getId());
+            return; // 대상자가 없으면 종료
+        }
 
-        // 3. 히스토리 엔티티 먼저 생성 (알림 1건 기준)
-        FcmSendHistory history = historyRepository.save(
-                FcmSendHistory.builder()
-                        .sender(manager.getUsers()) // 알림 보낸 사람 = 관리자
-                        .title(title)
-                        .body(set.getSetTitle())
-                        .category(FcmCategory.SPECIAL) // 또는 DAILY 등으로 상황에 맞게 지정
-                        .link(link)
-                        .sentAt(LocalDateTime.now())
-                        .targetCount(users.size()) // 전체 대상자 수
-                        .build()
-        );
-
-        // 4. 사용자별 FCM 전송 및 Notice 저장
+        LocalDateTime sentTime = LocalDateTime.now();
         int successCount = 0;
+        List<Notice> noticesToSave = new ArrayList<>();
+        String commonLink = "https://charti.site/surveySet/request/" + setId;
+        // 3. 자녀 한 명 한 명을 기준으로 반복
+        for (Child child : targetChildren) {
+            // Member를 통해 최종 Users 객체를 가져옵니다.
+            // child.getParent() -> Member, child.getParent().getUser() -> Users
+            Users parent = child.getParent().getUsers();
+            if (parent == null || parent.isDeleted()) continue;
+            // 4. 자녀별로 개별 메시지 생성
+            String title = String.format("[문진 요청] %s 어린이를 위한 새 문진이 도착했어요!", child.getName());
+            String body = String.format("'%s' 문진을 확인하고 답변을 부탁드립니다.", set.getSetTitle());
+            String link = "https://charti.site/surveySet/request/" + setId + "?childId=" + child.getId();
+            // 5. 학부모의 활성 토큰으로 FCM 발송
+            List<UserFcmToken> tokens = tokenRepository.findByUserAndIsActiveTrue(parent);
+            if (tokens.isEmpty()) continue;
 
-        for (Users user : users) {
-            List<UserFcmToken> tokens = tokenRepository.findByUserAndIsActiveTrue(user);
-            boolean sent = false;
-
+            boolean sentToUser = false;
             for (UserFcmToken token : tokens) {
                 try {
-                    firebaseMessagingService.sendMessageToToken(token.getFcmToken(), title, set.getSetTitle(), link);
-                    sent = true;
+                    firebaseMessagingService.sendMessageToToken(token.getFcmToken(), title, body, link);
+                    sentToUser = true;
                 } catch (Exception e) {
-                    log.warn("❌ FCM 발송 실패: userId={}, token={}", user.getId(), token.getFcmToken());
+                    log.warn("❌ FCM 발송 실패: userId={}, token={}", parent.getId(), token.getFcmToken(), e);
                 }
             }
-
-            if (sent) {
-                successCount++;
-            }
-
-            // Notice는 항상 저장 (알림함 확인용)
-            noticeRepository.save(
+            if (sentToUser) successCount++;
+            // 6. 생성된 개별 Notice를 리스트에 추가
+            noticesToSave.add(
                     Notice.builder()
-                            .user(user)
+                            .user(parent)
                             .title(title)
-                            .body(set.getSetTitle())
-                            .category(FcmCategory.SPECIAL)
+                            .body(body)
+                            .category(FcmCategory.GROUP)
                             .url(link)
-                            .sentAt(LocalDateTime.now())
+                            .sentAt(sentTime)
                             .build()
             );
         }
-
-        // 5. 성공 개수 반영
-        history.setSuccessCount(successCount);
+        // 7. 모든 Notice를 DB에 일괄 저장
+        noticeRepository.saveAll(noticesToSave);
+        // 8. 최종 결과로 발송 이력(History) 저장
+        historyRepository.save(
+                FcmSendHistory.builder()
+                        .sender(manager.getUsers())
+                        .title(set.getSetTitle())
+                        .body(String.format("%s 담당자가 그룹 문진을 발송했습니다.", manager.getUsers().getName()))
+                        .category(FcmCategory.GROUP)
+                        .targetCondition("groupId=" + manager.getGroup().getId())
+                        .link(commonLink)
+                        .targetCount(targetChildren.size())
+                        .successCount(successCount)
+                        .sentAt(sentTime)
+                        .build()
+        );
     }
-
 }

--- a/src/main/java/com/example/demo/survey/repository/SurveySetRepository.java
+++ b/src/main/java/com/example/demo/survey/repository/SurveySetRepository.java
@@ -37,5 +37,10 @@ public interface SurveySetRepository
 """)
     List<SurveySet> findAllByTargetGroupForManager(@Param("targetGroup") TargetGroup targetGroup);
 
+    /**
+     *  타입이 'GROUP'인 모든 문진 세트를 조회합니다.
+     * 담당자의 소속 그룹과 관계 없이, 모든 그룹 문진 세트를 가져옵니다.
+     */
+    List<SurveySet> findByType(String type);
 
 }

--- a/src/main/java/com/example/demo/survey/service/SurveySetService.java
+++ b/src/main/java/com/example/demo/survey/service/SurveySetService.java
@@ -11,6 +11,7 @@ import com.example.demo.users.entity.Manager;
 import com.example.demo.users.repository.ManagerRepository;
 import com.example.demo.users.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class SurveySetService {
 
     private final SurveySetRepository     surveySetRepo;
@@ -142,13 +144,29 @@ public class SurveySetService {
      * @param managerId 현재 로그인한 담당자 ID
      * @return 문진 세트 목록
      */
+//    public List<SurveySet> getSetsForManager(Long managerId) {
+//        Manager manager = managerRepo.findById(managerId)
+//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다."));
+//        TargetGroup targetGroup = manager.getGroup().getTargetGroup();
+//
+//        return surveySetRepo.findAllByTargetGroupForManager(targetGroup);
+//    }
     public List<SurveySet> getSetsForManager(Long managerId) {
         Manager manager = managerRepo.findById(managerId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다."));
-        TargetGroup targetGroup = manager.getGroup().getTargetGroup();
 
-        return surveySetRepo.findAllByTargetGroupForManager(targetGroup);
+        log.info("매니저 ID: {}", manager.getId());
+        log.info("소속 그룹 ID: {}", manager.getGroup() != null ? manager.getGroup().getId() : "null");
+
+        TargetGroup targetGroup = manager.getGroup() != null ? manager.getGroup().getTargetGroup() : null;
+        log.info("타겟 그룹: {}", targetGroup != null ? targetGroup.getDisplayName() : "null");
+
+        List<SurveySet> result = surveySetRepo.findByType("GROUP");
+        log.info("조회된 세트 수: {}", result.size());
+
+        return result;
     }
+
 
 
     /**

--- a/src/main/java/com/example/demo/users/repository/ChildRepository.java
+++ b/src/main/java/com/example/demo/users/repository/ChildRepository.java
@@ -29,4 +29,11 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
     // child.parent.users.id = ? 인 자녀들을 모두 가져옴
     List<Child> findByParentUsersId(Long usersId);
 
+    /**
+     * 특정 기관(Group) ID에 속한 모든 자녀 목록을 조회합니다.
+     * @param groupId 기관(Group)의 ID
+     * @return 자녀(Child) 목록
+     */
+    List<Child> findByGroupId(Long groupId);
+
 }

--- a/src/main/java/com/example/demo/users/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/users/repository/UserRepository.java
@@ -54,4 +54,12 @@ public interface UserRepository extends JpaRepository<Users,Long> {
      * @return 해당 그룹 소속 사용자 리스트
      */
     List<Users> findAllByManager_Group_Id(Long groupId);
+
+    /**
+     * 특정 기관(Group) ID에 자녀가 한 명 이상 소속된 모든 부모(Users)를 중복 없이 조회합니다.
+     * @param groupId 기관(Group)의 ID
+     * @return 부모(Users) 목록
+     */
+    @Query("SELECT DISTINCT u FROM Users u JOIN u.member.children c WHERE c.group.id = :groupId AND u.deleted = false")
+    List<Users> findParentsWithChildrenInGroup(@Param("groupId") Long groupId);
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -102,5 +102,30 @@
         </a>
     </div>
 
+    <div class="flex justify-center mt-6 space-x-6">
+
+        <!-- 테스트 할 때마다 링크 치기 불편해서 만든 임시 버튼 -->
+
+        <a href="/manager/notification/form" class="bg-blue-500 text-white p-3 rounded-lg w-[150px] text-center hover:bg-blue-600">
+            담당자 문진 알림 발송
+        </a>
+        <a href="/dailyAnswer/history" class="bg-blue-500 text-white p-3 rounded-lg w-[150px] text-center hover:bg-blue-600">
+            데
+        </a>
+        <a href="/groupSurvey" class="bg-blue-500 text-white p-3 rounded-lg w-[150px] text-center hover:bg-blue-600">
+            그
+        </a>
+
+        <a href="/groupAnswer/history" class="bg-blue-500 text-white p-3 rounded-lg w-[150px] text-center hover:bg-blue-600">
+            그
+        </a>
+        <a href="/specialSurvey" class="bg-blue-500 text-white p-3 rounded-lg w-[150px] text-center hover:bg-blue-600">
+            특
+        </a>
+        <a href="/specialAnswer/history" class="bg-blue-500 text-white p-3 rounded-lg w-[150px] text-center hover:bg-blue-600">
+            특
+        </a>
+    </div>
+
 </th:block>
 </html>

--- a/src/main/resources/templates/manager/notification/notificationForm.html
+++ b/src/main/resources/templates/manager/notification/notificationForm.html
@@ -25,8 +25,8 @@
                 <select name="setId" id="setId" class="w-full border p-2 rounded" required>
                     <option value="">세트를 선택해주세요</option>
                     <option th:each="s : ${surveySets}"
-                            th:value="${s.id}"
-                            th:text="${s.title}"></option>
+                            th:value="${s.setId}"
+                            th:text="${s.setTitle}"></option>
                 </select>
             </div>
 
@@ -48,8 +48,10 @@
 
         </form>
 
-        <p th:if="${message}" class="mt-6 text-green-600 font-semibold"
-           th:text="${message}"></p>
+        <div th:if="${message}" class="mt-4 mb-4 p-3 rounded text-sm"
+             th:classappend="${message.startsWith('❌')} ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'"
+             th:text="${message}">
+        </div>
     </div>
 
     <script>

--- a/src/main/resources/templates/survey/recordAnswerForm.html
+++ b/src/main/resources/templates/survey/recordAnswerForm.html
@@ -104,7 +104,7 @@
             <h2 class="text-lg font-semibold mb-2">자녀 정보</h2>
             <p><strong>이름:</strong> <span th:text="${selectedChild.name}"></span></p>
             <p><strong>성별:</strong> <span th:text="${selectedChild.gender}"></span></p>
-            <p><strong>나이:</strong> <span th:text="${selectedChild.age} "></span></p>
+            <p><strong>나이:</strong> <span th:text="${selectedChild.age}+'세'"></span></p>
             <p><strong>키:</strong> <span th:text="${selectedChild.height} "></span></p>
             <p><strong>체중:</strong> <span th:text="${selectedChild.weight} "></span></p>
         </div>


### PR DESCRIPTION
관리자(담당자)가 소속된 그룹의 학부모들에게 특정 문진 세트 참여를 독려하는 알림을 발송하는 기능을 신규 구현했습니다.

주요 기능 및 변경 사항
알림 발송 로직 구현 (FcmService)

담당자(Manager)의 소속 그룹(Group)을 기준으로, 해당 그룹에 속한 모든 자녀의 학부모를 조회합니다.

각 자녀의 이름이 포함된 개별 맞춤형 알림 메시지를 생성하여 FCM으로 발송합니다.

발송된 모든 개별 알림(Notice)과 전체 발송 이력(FcmSendHistory)을 데이터베이스에 저장합니다.

발송 이력에 담당자 이름, 발송 조건(groupId), 공통 링크(link) 등 상세 정보를 포함하도록 개선했습니다.

리포지토리 쿼리 추가 (UserRepository, ChildRepository)

findParentsWithChildrenInGroup: 특정 그룹에 속한 학부모를 중복 없이 효율적으로 조회하는 JPQL 쿼리를 추가했습니다.

findByGroupId: 특정 그룹 소속 자녀 목록을 조회하는 쿼리 메소드를 추가했습니다.

컨트롤러 및 뷰 구현

담당자가 문진 세트를 선택하고 알림을 보낼 수 있는 UI 페이지(notificationForm.html)를 추가했습니다.

알림 발송 요청을 처리하는 컨트롤러 로직을 구현하고, 발송 후 성공/실패 메시지를 화면에 표시하도록 처리했습니다.