### PR TITLE
0702박지수

### DIFF
--- a/src/main/java/com/example/demo/community/controller/AllPostsBoardController.java
+++ b/src/main/java/com/example/demo/community/controller/AllPostsBoardController.java
@@ -14,6 +14,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Controller
 @RequestMapping("/community/allPosts")
 public class AllPostsBoardController {
@@ -58,16 +61,39 @@ public class AllPostsBoardController {
     public String detail(
             @PathVariable Long id,
             @RequestParam(defaultValue = "0") int commentPage,
-            Model model
+            Model model,
+            Authentication auth
     ) {
+        // 게시글 + 조회수
         CommunityBoard board = boardService.findById(id);
-        board.setViews(board.getViews() + 1);
+        board.setViews(board.getViews()+1);
         boardService.save(board);
 
+        // 글 작성자 닉네임
+        String authorNickname = userService.findNicknameOrDefault(board.getUsersId());
+
+        // 댓글 페이징
         Page<Comment> commentsPage = commentService.getCommentsPage(id, commentPage);
 
-        model.addAttribute("board",        board);
-        model.addAttribute("commentsPage", commentsPage);
+        // 댓글 작성자 닉네임 리스트
+        List<String> commentNicknames = commentsPage.getContent().stream()
+                .map(c -> userService.findNicknameOrDefault(c.getUsersId()))
+                .collect(Collectors.toList());
+
+        // 댓글별 usersId 리스트
+        List<Long> commentUserIds = commentsPage.getContent().stream()
+                .map(Comment::getUsersId)
+                .collect(Collectors.toList());
+
+        // 로그인한 사용자 ID
+        Long currentUserId = getCurrentUserId(auth);
+
+        model.addAttribute("board",             board);
+        model.addAttribute("authorNickname", authorNickname);
+        model.addAttribute("commentsPage",      commentsPage);
+        model.addAttribute("commentNicknames",  commentNicknames);
+        model.addAttribute("commentUserIds",    commentUserIds);
+        model.addAttribute("currentUserId",     currentUserId);
         return "community/allPostsDetail";
     }
 
@@ -96,4 +122,51 @@ public class AllPostsBoardController {
         commentService.save(comment);
         return "redirect:/community/allPosts/" + id;
     }
+
+    // 댓글 수정
+    @PostMapping("/{boardId:[0-9]+}/comments/{commentId:[0-9]+}")
+    public String updateComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            @RequestParam String content,
+            Authentication auth
+    ) {
+        Comment c = commentService.findById(commentId);
+        Long me = getCurrentUserId(auth);
+        if (me != null && me.equals(c.getUsersId())) {
+            c.setContent(content);
+            commentService.save(c);
+        }
+        return "redirect:/community/allPosts/" + boardId;
+    }
+
+    // 댓글 삭제
+    @PostMapping("/{boardId:[0-9]+}/comments/{commentId:[0-9]+}/delete")
+    public String deleteComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            Authentication auth
+    ) {
+        Comment c = commentService.findById(commentId);
+        Long me = getCurrentUserId(auth);
+        if (me != null && me.equals(c.getUsersId())) {
+            commentService.delete(commentId);
+        }
+        return "redirect:/community/allPosts/" + boardId;
+    }
+
+    // 인증 객체 → Users ID 꺼내는 헬퍼
+    private Long getCurrentUserId(Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) return null;
+        String p = auth.getName();
+        Users me = null;
+        try { me = userService.findByUsernameEntity(p); }
+        catch (UserNotFoundException ignored) { }
+        if (me == null) {
+            try { me = userService.findByUuidEntity(p); }
+            catch (UserNotFoundException ignored) { }
+        }
+        return me != null ? me.getId() : null;
+    }
+
 }

--- a/src/main/java/com/example/demo/community/controller/AnnouncementBoardController.java
+++ b/src/main/java/com/example/demo/community/controller/AnnouncementBoardController.java
@@ -108,63 +108,41 @@ public class AnnouncementBoardController {
     @GetMapping("/{id:[0-9]+}")
     public String detail(
             @PathVariable Long id,
-            @RequestParam(defaultValue="0") int commentPage,
+            @RequestParam(defaultValue = "0") int commentPage,
             Model model,
             Authentication auth
     ) {
-        // 1) 조회수 증가
+        // 게시글 + 조회수
         CommunityBoard board = boardService.findById(id);
         board.setViews(board.getViews()+1);
         boardService.save(board);
 
-        // 2) 댓글 페이징
-        Page<Comment> commentsPage = commentService.getCommentsPage(id, commentPage);
-
-        // 3) 글 작성자 닉네임
+        // 글 작성자 닉네임
         String authorNickname = userService.findNicknameOrDefault(board.getUsersId());
 
-        // 4) 댓글 작성자 닉네임 리스트
+        // 댓글 페이징
+        Page<Comment> commentsPage = commentService.getCommentsPage(id, commentPage);
+
+        // 댓글 작성자 닉네임 리스트
         List<String> commentNicknames = commentsPage.getContent().stream()
                 .map(c -> userService.findNicknameOrDefault(c.getUsersId()))
                 .collect(Collectors.toList());
 
-        // 5) 로그인한 사용자 ID (버튼 노출 제어용)
-        Long currentUserId = null;
-        if (auth != null && auth.isAuthenticated()) {
-            try {
-                currentUserId = userService.findByUsernameEntity(auth.getName()).getId();
-            } catch (UserNotFoundException e) {
-                currentUserId = userService.findByUuidEntity(auth.getName()).getId();
-            }
-        }
+        // 댓글별 usersId 리스트
+        List<Long> commentUserIds = commentsPage.getContent().stream()
+                .map(Comment::getUsersId)
+                .collect(Collectors.toList());
 
-        model.addAttribute("board",            board);
-        model.addAttribute("commentsPage",     commentsPage);
-        model.addAttribute("authorNickname",   authorNickname);
-        model.addAttribute("commentNicknames", commentNicknames);
-        model.addAttribute("currentUserId",    currentUserId);
+        // 로그인한 사용자 ID
+        Long currentUserId = getCurrentUserId(auth);
+
+        model.addAttribute("board",             board);
+        model.addAttribute("authorNickname", authorNickname);
+        model.addAttribute("commentsPage",      commentsPage);
+        model.addAttribute("commentNicknames",  commentNicknames);
+        model.addAttribute("commentUserIds",    commentUserIds);
+        model.addAttribute("currentUserId",     currentUserId);
         return "community/announcementDetail";
-    }
-
-    @PostMapping("/{id:[0-9]+}/comments")
-    public String addComment(
-            @PathVariable Long id,
-            @RequestParam String content,
-            Authentication auth
-    ) {
-        String principal = auth.getName();
-        Users me;
-        try {
-            me = userService.findByUsernameEntity(principal);
-        } catch (UserNotFoundException e) {
-            me = userService.findByUuidEntity(principal);
-        }
-        Comment c = new Comment();
-        c.setCommunityId(id);
-        c.setUsersId(me.getId());
-        c.setContent(content);
-        commentService.save(c);
-        return "redirect:/community/announcement/" + id;
     }
 
     @GetMapping("/{id:[0-9]+}/edit")
@@ -206,4 +184,73 @@ public class AnnouncementBoardController {
         boardService.delete(id);
         return "redirect:/community/announcement/list";
     }
+
+    // 댓글 작성 처리
+    @PostMapping("/{id:[0-9]+}/comments")
+    public String addComment(
+            @PathVariable Long id,
+            @RequestParam String content,
+            Authentication auth
+    ) {
+        String principal = auth.getName();
+        Users me;
+        try {
+            me = userService.findByUsernameEntity(principal);
+        } catch (UserNotFoundException e) {
+            me = userService.findByUuidEntity(principal);
+        }
+        Comment c = new Comment();
+        c.setCommunityId(id);
+        c.setUsersId(me.getId());
+        c.setContent(content);
+        commentService.save(c);
+        return "redirect:/community/announcement/" + id;
+    }
+
+    // 댓글 수정
+    @PostMapping("/{boardId:[0-9]+}/comments/{commentId:[0-9]+}")
+    public String updateComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            @RequestParam String content,
+            Authentication auth
+    ) {
+        Comment c = commentService.findById(commentId);
+        Long me = getCurrentUserId(auth);
+        if (me != null && me.equals(c.getUsersId())) {
+            c.setContent(content);
+            commentService.save(c);
+        }
+        return "redirect:/community/announcement/" + boardId;
+    }
+
+    // 댓글 삭제
+    @PostMapping("/{boardId:[0-9]+}/comments/{commentId:[0-9]+}/delete")
+    public String deleteComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            Authentication auth
+    ) {
+        Comment c = commentService.findById(commentId);
+        Long me = getCurrentUserId(auth);
+        if (me != null && me.equals(c.getUsersId())) {
+            commentService.delete(commentId);
+        }
+        return "redirect:/community/announcement/" + boardId;
+    }
+
+    // 인증 객체 → Users ID 꺼내는 헬퍼
+    private Long getCurrentUserId(Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) return null;
+        String p = auth.getName();
+        Users me = null;
+        try { me = userService.findByUsernameEntity(p); }
+        catch (UserNotFoundException ignored) { }
+        if (me == null) {
+            try { me = userService.findByUuidEntity(p); }
+            catch (UserNotFoundException ignored) { }
+        }
+        return me != null ? me.getId() : null;
+    }
+
 }

--- a/src/main/java/com/example/demo/community/controller/ParentingBoardController.java
+++ b/src/main/java/com/example/demo/community/controller/ParentingBoardController.java
@@ -108,60 +108,37 @@ public class ParentingBoardController {
             Model model,
             Authentication auth
     ) {
-        // 1) 게시글 + 조회수
+        // 게시글 + 조회수
         CommunityBoard board = boardService.findById(id);
-        board.setViews(board.getViews() + 1);
+        board.setViews(board.getViews()+1);
         boardService.save(board);
 
-        // 2) 댓글 페이징
-        Page<Comment> commentsPage = commentService.getCommentsPage(id, commentPage);
-
-        // 3) 글 작성자 닉네임
+        // 글 작성자 닉네임
         String authorNickname = userService.findNicknameOrDefault(board.getUsersId());
 
-        // 4) 댓글 작성자 닉네임 리스트
+        // 댓글 페이징
+        Page<Comment> commentsPage = commentService.getCommentsPage(id, commentPage);
+
+        // 댓글 작성자 닉네임 리스트
         List<String> commentNicknames = commentsPage.getContent().stream()
                 .map(c -> userService.findNicknameOrDefault(c.getUsersId()))
                 .collect(Collectors.toList());
 
-        // 5) 로그인한 사용자 ID (수정/삭제 버튼용)
-        Long currentUserId = null;
-        if (auth != null && auth.isAuthenticated()) {
-            try {
-                Users u = userService.findByUsernameEntity(auth.getName());
-                currentUserId = u.getId();
-            } catch (UserNotFoundException e) {
-                currentUserId = userService.findByUuidEntity(auth.getName()).getId();
-            }
-        }
+        // 댓글별 usersId 리스트
+        List<Long> commentUserIds = commentsPage.getContent().stream()
+                .map(Comment::getUsersId)
+                .collect(Collectors.toList());
 
-        model.addAttribute("board",            board);
-        model.addAttribute("commentsPage",     commentsPage);
-        model.addAttribute("authorNickname",   authorNickname);
-        model.addAttribute("commentNicknames", commentNicknames);
-        model.addAttribute("currentUserId",    currentUserId);
+        // 로그인한 사용자 ID
+        Long currentUserId = getCurrentUserId(auth);
+
+        model.addAttribute("board",             board);
+        model.addAttribute("authorNickname", authorNickname);
+        model.addAttribute("commentsPage",      commentsPage);
+        model.addAttribute("commentNicknames",  commentNicknames);
+        model.addAttribute("commentUserIds",    commentUserIds);
+        model.addAttribute("currentUserId",     currentUserId);
         return "community/parentingDetail";
-    }
-
-    @PostMapping("/{id:[0-9]+}/comments")
-    public String addComment(
-            @PathVariable Long id,
-            @RequestParam String content,
-            Authentication auth
-    ) {
-        String principal = auth.getName();
-        Users me;
-        try {
-            me = userService.findByUsernameEntity(principal);
-        } catch (UserNotFoundException e) {
-            me = userService.findByUuidEntity(principal);
-        }
-        Comment comment = new Comment();
-        comment.setCommunityId(id);
-        comment.setUsersId(me.getId());
-        comment.setContent(content);
-        commentService.save(comment);
-        return "redirect:/community/parenting/" + id;
     }
 
     @GetMapping("/{id:[0-9]+}/edit")
@@ -192,5 +169,73 @@ public class ParentingBoardController {
     public String delete(@PathVariable Long id) {
         boardService.delete(id);
         return "redirect:/community/parenting/list";
+    }
+
+    // 댓글 작성 처리
+    @PostMapping("/{id:[0-9]+}/comments")
+    public String addComment(
+            @PathVariable Long id,
+            @RequestParam String content,
+            Authentication auth
+    ) {
+        String principal = auth.getName();
+        Users me;
+        try {
+            me = userService.findByUsernameEntity(principal);
+        } catch (UserNotFoundException e) {
+            me = userService.findByUuidEntity(principal);
+        }
+        Comment comment = new Comment();
+        comment.setCommunityId(id);
+        comment.setUsersId(me.getId());
+        comment.setContent(content);
+        commentService.save(comment);
+        return "redirect:/community/parenting/" + id;
+    }
+
+    // 댓글 수정
+    @PostMapping("/{boardId:[0-9]+}/comments/{commentId:[0-9]+}")
+    public String updateComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            @RequestParam String content,
+            Authentication auth
+    ) {
+        Comment c = commentService.findById(commentId);
+        Long me = getCurrentUserId(auth);
+        if (me != null && me.equals(c.getUsersId())) {
+            c.setContent(content);
+            commentService.save(c);
+        }
+        return "redirect:/community/parenting/" + boardId;
+    }
+
+    // 댓글 삭제
+    @PostMapping("/{boardId:[0-9]+}/comments/{commentId:[0-9]+}/delete")
+    public String deleteComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            Authentication auth
+    ) {
+        Comment c = commentService.findById(commentId);
+        Long me = getCurrentUserId(auth);
+        if (me != null && me.equals(c.getUsersId())) {
+            commentService.delete(commentId);
+        }
+        return "redirect:/community/parenting/" + boardId;
+    }
+
+    // 인증 객체 → Users ID 꺼내는 헬퍼
+    private Long getCurrentUserId(Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) return null;
+        String p = auth.getName();
+        Users me = null;
+        try { me = userService.findByUsernameEntity(p); }
+        catch (UserNotFoundException ignored) { }
+        if (me == null) {
+            try { me = userService.findByUuidEntity(p); }
+            catch (UserNotFoundException ignored) { }
+        }
+        return me != null ? me.getId() : null;
     }
 }

--- a/src/main/java/com/example/demo/community/controller/PolicyBoardController.java
+++ b/src/main/java/com/example/demo/community/controller/PolicyBoardController.java
@@ -126,47 +126,36 @@ public class PolicyBoardController {
             Model model,
             Authentication auth
     ) {
-        // 1) 게시글 + 조회수
+        // 게시글 + 조회수
         CommunityBoard board = boardService.findById(id);
-        board.setViews(board.getViews() + 1);
+        board.setViews(board.getViews()+1);
         boardService.save(board);
 
-        // 2) 댓글 페이징
-        Page<Comment> commentsPage = commentService.getCommentsPage(id, commentPage);
-
-        // 3) 작성자 닉네임
+        // 글 작성자 닉네임
         String authorNickname = userService.findNicknameOrDefault(board.getUsersId());
 
-        // 4-1) 댓글 작성자 닉네임 리스트 (
+        // 댓글 페이징
+        Page<Comment> commentsPage = commentService.getCommentsPage(id, commentPage);
+
+        // 댓글 작성자 닉네임 리스트
         List<String> commentNicknames = commentsPage.getContent().stream()
                 .map(c -> userService.findNicknameOrDefault(c.getUsersId()))
                 .collect(Collectors.toList());
 
-        // 4-2) 댓글별 usersId 리스트
+        // 댓글별 usersId 리스트
         List<Long> commentUserIds = commentsPage.getContent().stream()
                 .map(Comment::getUsersId)
                 .collect(Collectors.toList());
 
-        // 5) 로그인한 사용자 ID
-        Long currentUserId = null;
-        if (auth != null && auth.isAuthenticated()) {
-            String p = auth.getName();
-            Users me = null;
-            try { me = userService.findByUsernameEntity(p); }
-            catch (UserNotFoundException ignored) { }
-            if (me == null) {
-                try { me = userService.findByUuidEntity(p); }
-                catch (UserNotFoundException ignored) { }
-            }
-            if (me != null) currentUserId = me.getId();
-        }
+        // 로그인한 사용자 ID
+        Long currentUserId = getCurrentUserId(auth);
 
-        model.addAttribute("board",            board);
-        model.addAttribute("commentsPage",     commentsPage);
-        model.addAttribute("authorNickname",   authorNickname);
-        model.addAttribute("commentNicknames", commentNicknames);
-        model.addAttribute("commentUserIds",   commentUserIds);
-        model.addAttribute("currentUserId",    currentUserId);
+        model.addAttribute("board",             board);
+        model.addAttribute("authorNickname", authorNickname);
+        model.addAttribute("commentsPage",      commentsPage);
+        model.addAttribute("commentNicknames",  commentNicknames);
+        model.addAttribute("commentUserIds",    commentUserIds);
+        model.addAttribute("currentUserId",     currentUserId);
         return "community/policyDetail";
     }
 
@@ -237,9 +226,7 @@ public class PolicyBoardController {
         return "redirect:/community/policy/" + id;
     }
 
-    /**
-     * 댓글 수정 처리
-     */
+    // 댓글 수정
     @PostMapping("/{boardId:[0-9]+}/comments/{commentId:[0-9]+}")
     public String updateComment(
             @PathVariable Long boardId,
@@ -247,24 +234,16 @@ public class PolicyBoardController {
             @RequestParam String content,
             Authentication auth
     ) {
-        // 1) DB에서 댓글을 가져온 뒤
         Comment c = commentService.findById(commentId);
-
-        // 2) 현재 로그인한 유저 ID와 댓글 작성자 ID를 비교
-        Long currentUserId = getCurrentUserId(auth);
-        if (currentUserId != null && currentUserId.equals(c.getUsersId())) {
-            // 3) 본인이 작성한 댓글이면 내용 업데이트
+        Long me = getCurrentUserId(auth);
+        if (me != null && me.equals(c.getUsersId())) {
             c.setContent(content);
             commentService.save(c);
         }
-
-        // 4) 상세 페이지로 리다이렉트
         return "redirect:/community/policy/" + boardId;
     }
 
-    /**
-     * 댓글 삭제 처리
-     */
+    // 댓글 삭제
     @PostMapping("/{boardId:[0-9]+}/comments/{commentId:[0-9]+}/delete")
     public String deleteComment(
             @PathVariable Long boardId,
@@ -272,23 +251,25 @@ public class PolicyBoardController {
             Authentication auth
     ) {
         Comment c = commentService.findById(commentId);
-        Long currentUserId = getCurrentUserId(auth);
-        if (currentUserId != null && currentUserId.equals(c.getUsersId())) {
+        Long me = getCurrentUserId(auth);
+        if (me != null && me.equals(c.getUsersId())) {
             commentService.delete(commentId);
         }
         return "redirect:/community/policy/" + boardId;
     }
 
-    /**
-     * 인증 객체에서 Users ID를 꺼내는 헬퍼
-     */
+    // 인증 객체 → Users ID 꺼내는 헬퍼
     private Long getCurrentUserId(Authentication auth) {
         if (auth == null || !auth.isAuthenticated()) return null;
-        String principal = auth.getName();
-        try {
-            return userService.findByUsernameEntity(principal).getId();
-        } catch (UserNotFoundException e) {
-            return userService.findByUuidEntity(principal).getId();
+        String p = auth.getName();
+        Users me = null;
+        try { me = userService.findByUsernameEntity(p); }
+        catch (UserNotFoundException ignored) { }
+        if (me == null) {
+            try { me = userService.findByUuidEntity(p); }
+            catch (UserNotFoundException ignored) { }
         }
+        return me != null ? me.getId() : null;
     }
+
 }

--- a/src/main/java/com/example/demo/community/repository/CommentRepository.java
+++ b/src/main/java/com/example/demo/community/repository/CommentRepository.java
@@ -11,4 +11,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByCommunityId(Long communityId, Pageable pageable);
 
     Page<Comment> findAllByCommunityIdAndDeletedFalse(Long communityId, Pageable pageable);
+
+    List<Comment> findByCommunityIdAndDeletedFalseOrderByCreatedAtAsc(Long communityId);
 }

--- a/src/main/java/com/example/demo/community/service/CommentService.java
+++ b/src/main/java/com/example/demo/community/service/CommentService.java
@@ -21,7 +21,7 @@ public class CommentService {
      * 지정된 게시글 ID에 달린 댓글 전체를 조회하여 오름차순(등록 시간 순)으로 반환합니다.
      */
     public List<Comment> getComments(Long communityId) {
-        return repo.findByCommunityIdOrderByCreatedAtAsc(communityId);
+        return repo.findByCommunityIdAndDeletedFalseOrderByCreatedAtAsc(communityId);
     }
 
     /**
@@ -31,7 +31,7 @@ public class CommentService {
      */
     public Page<Comment> getCommentsPage(Long communityId, int page) {
         Pageable pageable = PageRequest.of(page, 5, Sort.by(Sort.Order.asc("createdAt")));
-        return repo.findByCommunityId(communityId, pageable);
+        return repo.findAllByCommunityIdAndDeletedFalse(communityId, pageable);
     }
     /** 단일 댓글 조회 (수정/삭제 전 권한 체크 등에 사용) */
     public Comment findById(Long commentId) {

--- a/src/main/java/com/example/demo/controller/QnaController.java
+++ b/src/main/java/com/example/demo/controller/QnaController.java
@@ -47,6 +47,8 @@ public class QnaController {
     @GetMapping("/admin/qna")
     public String adminQna(@RequestParam(value = "page", defaultValue = "1", required=false) int page,
                            @RequestParam(value = "category", required=false) QnaCategory category,
+                           @RequestParam(value = "status", required = false) String status,
+                           @RequestParam(value = "keyword", required = false) String keyword,
                            Model model) {
 
         AdminDTO adminDTO = authService.getLoginAdmin();
@@ -56,14 +58,15 @@ public class QnaController {
             return "redirect:/qna";
         }
 
-        Page<Qna> qnaPage = qnaService.getAdminPagedList(category, page-1);
+        Page<Qna> qnaPage = qnaService.getAdminPagedList(category, status, keyword, page-1);
+        List<QnaDTO>   qnaList = getQnaList(qnaPage);
 
-        List<QnaDTO> qnaList = getQnaList(qnaPage);
-
-        model.addAttribute("category", QnaCategory.values());
+        model.addAttribute("category",         QnaCategory.values());
+        model.addAttribute("selectedCategory", category);
+        model.addAttribute("selectedStatus", status);
+        model.addAttribute("keyword", keyword);
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", qnaPage.getTotalPages());
-        model.addAttribute("selectedCategory", category);
         model.addAttribute("qnaList", qnaList);
         return "admin/adminQnaList";
     }

--- a/src/main/java/com/example/demo/repository/QnaRepository.java
+++ b/src/main/java/com/example/demo/repository/QnaRepository.java
@@ -4,6 +4,7 @@ import com.example.demo.entity.Qna;
 import com.example.demo.enums.QnaCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,6 @@ public interface QnaRepository extends JpaRepository<Qna, Long> {
     Page<Qna> findAllByUsers_Id(Long id, Pageable pageable);
 
     Page<Qna> findAllByUsers_IdAndCategory(Long id, QnaCategory category, Pageable pageable);
+
+    Page<Qna> findAll(Specification<Qna> spec, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/service/QnaService.java
+++ b/src/main/java/com/example/demo/service/QnaService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,13 +31,35 @@ public class QnaService extends BaseService<Qna, QnaRepository> {
         }
     }
 
-    public Page<Qna> getAdminPagedList(QnaCategory category, int page) {
+    public Page<Qna> getAdminPagedList(
+            QnaCategory category,
+            String status,
+            String keyword,
+            int page
+    ) {
         Pageable pageable = PageRequest.of(page, 10, Sort.Direction.DESC, "createdAt");
 
-        if(category == null) {
-            return repository.findAll(pageable);
+        Specification<Qna> spec = Specification.where(null);
+
+        if (category != null) {
+            spec = spec.and((root, q, cb) -> cb.equal(root.get("category"), category));
         }
-        return repository.findAllByCategory(category, pageable);
+
+        if (status != null) {
+            if (status.equals("waiting")) {
+                spec = spec.and((r, q, cb) -> cb.isFalse(r.get("isAnswered")));
+            } else if (status.equals("done")) {
+                spec = spec.and((r, q, cb) -> cb.isTrue(r.get("isAnswered")));
+            }
+        }
+
+        if (keyword != null && !keyword.isBlank()) {
+            spec = spec.and((r, q, cb) ->
+                    cb.like(cb.lower(r.get("title")), "%" + keyword.toLowerCase() + "%")
+            );
+        }
+
+        return repository.findAll(spec, pageable);
     }
 
     public Long createQna(Qna qna) {

--- a/src/main/java/com/example/demo/survey/controller/GroupSurveyManagerController.java
+++ b/src/main/java/com/example/demo/survey/controller/GroupSurveyManagerController.java
@@ -2,22 +2,27 @@ package com.example.demo.survey.controller;
 
 import com.example.demo.enums.AgeGroup;
 import com.example.demo.enums.SurveyCategory;
+import com.example.demo.enums.TargetGroup;
 import com.example.demo.survey.entity.DailySurvey;
 import com.example.demo.survey.entity.GroupAnswer;
 import com.example.demo.survey.entity.GroupSurvey;
 import com.example.demo.survey.service.GroupAnswerService;
 import com.example.demo.survey.service.GroupSurveyService;
+import com.example.demo.users.entity.Manager;
+import com.example.demo.users.repository.ManagerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Controller
@@ -26,6 +31,7 @@ import java.util.stream.Collectors;
 public class GroupSurveyManagerController {
 
     private final GroupSurveyService groupSurveyService;
+    private final ManagerRepository managerRepository;
     private final List<AgeGroup> ageGroups = Arrays.stream(AgeGroup.values())
             .filter(ag -> ag != AgeGroup.ALL && ag != AgeGroup.VARIOUS)
             .collect(Collectors.toList());
@@ -34,38 +40,34 @@ public class GroupSurveyManagerController {
             .collect(Collectors.toList());
     private final GroupAnswerService groupAnswerService;
 
-    // 1. 설문 리스트 (연령대, 카테고리 필터링)
+    // 1. 설문 리스트 (연령대, 카테고리 필터링, TargetGroup 필터링)
     @GetMapping({"", "/list"})
     public String list(
             @RequestParam(defaultValue = "ALL") AgeGroup ageGroup,
             @RequestParam(defaultValue = "ALL") SurveyCategory category,
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            Authentication auth ,
             Model model
     ) {
         // service 쪽에서 distinct 카테고리를 enum 리스트로 반환하도록 수정했다면
         List<SurveyCategory> categories = groupSurveyService.getDistinctCategories();
 
-        Page<GroupSurvey> surveys;
-        if (ageGroup == AgeGroup.ALL && category == SurveyCategory.ALL) {
-            // 전체
-            surveys = groupSurveyService.findAllSurveys(pageable);
-        } else if (ageGroup != AgeGroup.ALL && category == SurveyCategory.ALL) {
-            // 연령대만 필터
-            surveys = groupSurveyService.getSurveysByAgeGroup(ageGroup, pageable);
-        } else if (ageGroup == AgeGroup.ALL && category != SurveyCategory.ALL) {
-            // 카테고리만 필터
-            surveys = groupSurveyService.getSurveysByCategory(category, pageable);
-        } else {
-            // 둘 다 필터
-            surveys = groupSurveyService.getSurveysByAgeAndCategory(ageGroup, category, pageable);
-        }
+        // 로그인한 매니저
+        Manager mgr = managerRepository.findByUsers_Uuid(auth.getName())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저"));
+        TargetGroup myGroup = mgr.getGroup().getTargetGroup();
+
+        // service 쪽에서 TargetGroup까지 처리하도록 새 메서드
+        Page<GroupSurvey> surveys = groupSurveyService.findByFilters(
+                ageGroup, category, myGroup, pageable
+        );
 
         model.addAttribute("ageGroup", ageGroup);
         model.addAttribute("category", category);
         model.addAttribute("ageGroups", ageGroups);
-        model.addAttribute("categories", categories);
+        model.addAttribute("categories", allCategories);
         model.addAttribute("surveys", surveys);
-        return "admin/manager/groupList";
+        return "manager/surveys/groupList";
     }
 
     // 2. 설문 작성 폼
@@ -74,12 +76,18 @@ public class GroupSurveyManagerController {
         model.addAttribute("survey", new GroupSurvey());
         model.addAttribute("ageGroups", ageGroups);
         model.addAttribute("categories", allCategories);
-        return "admin/manager/groupForm";
+        return "manager/surveys/groupForm";
     }
 
-    // 2. 설문 저장 처리
+    // 2. 설문 저장 처리(TargetGroup 자동 설정)
     @PostMapping
-    public String create(@ModelAttribute GroupSurvey survey) {
+    public String create(
+            @ModelAttribute GroupSurvey survey,
+            Authentication auth
+    ) {
+        Manager mgr = managerRepository.findByUsers_Uuid(auth.getName())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저"));
+        survey.setTargetGroup(mgr.getGroup().getTargetGroup());
         groupSurveyService.save(survey);
         return "redirect:/manager/surveys/group";
     }
@@ -91,7 +99,7 @@ public class GroupSurveyManagerController {
         model.addAttribute("survey", survey);
         model.addAttribute("ageGroups", ageGroups);
         model.addAttribute("categories", allCategories);
-        return "admin/manager/groupForm";
+        return "manager/surveys/groupForm";
     }
 
     // 3. 설문 수정 처리
@@ -101,6 +109,7 @@ public class GroupSurveyManagerController {
             @ModelAttribute DailySurvey formData
     ) {
         GroupSurvey survey = groupSurveyService.findById(id);
+
         // formData.getAgeGroup() 은 이제 AgeGroup enum
         survey.setAgeGroup(formData.getAgeGroup());
         survey.setCategory(formData.getCategory());

--- a/src/main/java/com/example/demo/survey/controller/SurveySetManagerController.java
+++ b/src/main/java/com/example/demo/survey/controller/SurveySetManagerController.java
@@ -27,7 +27,7 @@ import java.util.List;
 @Controller
 @RequestMapping("/manager/surveySet")
 @RequiredArgsConstructor
-public class ManagerSurveySetController {
+public class SurveySetManagerController {
 
     private final SurveySetService service;
     private final ManagerRepository managerRepo;

--- a/src/main/java/com/example/demo/survey/repository/GroupSurveyRepository.java
+++ b/src/main/java/com/example/demo/survey/repository/GroupSurveyRepository.java
@@ -2,6 +2,7 @@ package com.example.demo.survey.repository;
 
 import com.example.demo.enums.AgeGroup;
 import com.example.demo.enums.SurveyCategory;
+import com.example.demo.enums.TargetGroup;
 import com.example.demo.survey.entity.GroupSurvey;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,4 +45,16 @@ public interface GroupSurveyRepository extends JpaRepository<GroupSurvey, Long> 
     Page<GroupSurvey> findAllByCategoryAndDeletedFalse(SurveyCategory category, Pageable pageable);
 
     Page<GroupSurvey> findByAgeGroupAndCategoryAndDeletedFalse(AgeGroup ageGroup, SurveyCategory category, Pageable pageable);
+
+    Page<GroupSurvey> findByTargetGroupAndDeletedFalse(
+            TargetGroup tg, Pageable p);
+
+    Page<GroupSurvey> findByAgeGroupAndTargetGroupAndDeletedFalse(
+            AgeGroup ag, TargetGroup tg, Pageable p);
+
+    Page<GroupSurvey> findByCategoryAndTargetGroupAndDeletedFalse(
+            SurveyCategory sc, TargetGroup tg, Pageable p);
+
+    Page<GroupSurvey> findByAgeGroupAndCategoryAndTargetGroupAndDeletedFalse(
+            AgeGroup ag, SurveyCategory sc, TargetGroup tg, Pageable p);
 }

--- a/src/main/java/com/example/demo/survey/service/GroupSurveyService.java
+++ b/src/main/java/com/example/demo/survey/service/GroupSurveyService.java
@@ -271,4 +271,31 @@ public class GroupSurveyService {
     public GroupSurvey findById(Long id) {
         return groupSurveyRepository.findById(id).orElse(null);
     }
+
+    /**
+     * 연령·카테고리·TargetGroup 조건으로 페이징 조회
+     */
+    public Page<GroupSurvey> findByFilters(
+            AgeGroup ageGroup,
+            SurveyCategory category,
+            TargetGroup targetGroup,
+            Pageable pageable
+    ) {
+        if (ageGroup == AgeGroup.ALL && category == SurveyCategory.ALL) {
+            return groupSurveyRepository
+                    .findByTargetGroupAndDeletedFalse(targetGroup, pageable);
+        }
+        if (ageGroup != AgeGroup.ALL && category == SurveyCategory.ALL) {
+            return groupSurveyRepository
+                    .findByAgeGroupAndTargetGroupAndDeletedFalse(ageGroup, targetGroup, pageable);
+        }
+        if (ageGroup == AgeGroup.ALL && category != SurveyCategory.ALL) {
+            return groupSurveyRepository
+                    .findByCategoryAndTargetGroupAndDeletedFalse(category, targetGroup, pageable);
+        }
+        // 둘 다 필터
+        return groupSurveyRepository
+                .findByAgeGroupAndCategoryAndTargetGroupAndDeletedFalse(
+                        ageGroup, category, targetGroup, pageable);
+    }
 }

--- a/src/main/resources/templates/admin/adminQnaList.html
+++ b/src/main/resources/templates/admin/adminQnaList.html
@@ -11,149 +11,187 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap"
           rel="stylesheet">
 </head>
+
 <th:block layout:fragment="content">
     <div class="max-w-7xl mx-auto bg-white shadow p-6 mt-8 mb-8 rounded">
-<div class="flex flex-1">
-    <div class="flex-1 justify-center items-center p-20">
-        <h1 class="text-3xl font-bold text-gray-800 mb-6">1:1 문의 관리</h1>
-        <hr class="mb-8 border-gray-300">
+        <div class="flex-1 p-6">
+            <h1 class="text-3xl font-bold text-gray-800 mb-6">1:1 문의 관리</h1>
+            <hr class="mb-8 border-gray-300">
 
-        <div class="w-1/4 mb-8">
-            <label class="block text-sm font-medium text-gray-700 mb-1">
-                카테고리
-            </label>
-            <select name="category" id="category"
-                    class="block w-full py-2 px-3 border border-gray-300 rounded-md
-                             shadow-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500
-                             transition duration-150 ease-in-out">
-                <option value="" th:selected="${selectedCategory == null}">전체</option>
-                <option th:each="category : ${category}"
-                        th:value="${category.name()}"
-                        th:text="${category.displayName}"
-                        th:selected="${category == selectedCategory}"></option>
-            </select>
-        </div>
+            <!-- 필터 & 검색 폼 (버튼 type="button" 으로 폼 제출 방지) -->
+            <form id="qnaFilterForm" class="mb-6 flex space-x-4">
+                <!-- 카테고리 -->
+                <div class="w-1/4">
+                    <label for="categorySelect" class="block text-sm font-medium text-gray-700 mb-1">
+                        카테고리
+                    </label>
+                    <select id="categorySelect" name="category"
+                            class="block w-full py-2 px-3 border rounded-md">
+                        <option value="" th:selected="${selectedCategory == null}">전체</option>
+                        <option th:each="cat : ${category}"
+                                th:value="${cat.name()}"
+                                th:text="${cat.displayName}"
+                                th:selected="${cat == selectedCategory}">
+                        </option>
+                    </select>
+                </div>
 
-        <div class="overflow-x-auto bg-white rounded-lg shadow">
-            <table class="min-w-full divide-y divide-gray-200 table-fixed">
-                <thead class="bg-gray-50">
-                <tr>
-                    <th class="w-[10%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        번호
-                    </th>
-                    <th class="w-[50%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        제목
-                    </th>
-                    <th class="w-[10%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <!-- 상태 -->
+                <div>
+                    <label for="statusSelect" class="block text-sm font-medium text-gray-700 mb-1">
                         상태
-                    </th>
-                    <th class="w-[10%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        작성자
-                    </th>
-                    <th class="w-[20%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        작성일
-                    </th>
-                </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                <tr th:each="qna : ${qnaList}">
-                    <td th:text="${qna.id}" class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"></td>
-                    <td class="px-6 py-4 whitespace-nowrap">
-                        <a th:href="@{/admin/qna/{id}(id=${qna.id})}" th:text="|${qna.title}${qna.deleted ? ' (삭제됨)' : ''}|"
-                           class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"></a>
-                    </td>
-                    <td th:text="${qna.isAnswered ? '답변 완료' : '답변 대기'}"
-                        class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"></td>
-                    <td th:text="${qna.nickname != null ? qna.nickname : qna.name }"
-                        class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"></td>
-                    <td th:text="${qna.createdAt}"
-                        class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"></td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
+                    </label>
+                    <select id="statusSelect" name="status"
+                            class="block py-2 px-3 border rounded-md">
+                        <option value="" th:selected="${selectedStatus == null}">전체</option>
+                        <option value="waiting" th:selected="${selectedStatus=='waiting'}">답변대기</option>
+                        <option value="done"    th:selected="${selectedStatus=='done'}">답변완료</option>
+                    </select>
+                </div>
 
-        <div class="flex justify-center mt-6 mx-6">
-            <nav id="pagination"
-                 th:data-current-page="${currentPage}"
-                 th:data-total-pages="${totalPages}"
-                 class="inline-flex -space-x-px">
+                <!-- 제목 검색 -->
+                <div class="flex-1">
+                    <label for="keywordInput" class="block text-sm font-medium text-gray-700 mb-1">
+                        제목 검색
+                    </label>
+                    <div class="flex">
+                        <input id="keywordInput" type="text" name="keyword"
+                               th:value="${keyword}"
+                               placeholder="제목 검색"
+                               class="flex-1 border rounded-l-md px-3 py-2"/>
+                        <button id="searchBtn" type="button"
+                                class="bg-blue-500 text-white px-4 py-2 rounded-r-md hover:bg-blue-600">
+                            검색
+                        </button>
+                    </div>
+                </div>
+            </form>
 
-            </nav>
+            <!-- QnA 테이블 -->
+            <div class="overflow-x-auto bg-white rounded-lg shadow">
+                <table class="min-w-full divide-y divide-gray-200 table-fixed">
+                    <thead class="bg-gray-50">
+                    <tr>
+                        <th class="w-[10%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                            번호
+                        </th>
+                        <th class="w-[50%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                            제목
+                        </th>
+                        <th class="w-[10%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                            상태
+                        </th>
+                        <th class="w-[10%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                            작성자
+                        </th>
+                        <th class="w-[20%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                            작성일
+                        </th>
+                    </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                    <tr th:each="qna : ${qnaList}">
+                        <td th:text="${qna.id}" class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"></td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <a th:href="@{/admin/qna/{id}(id=${qna.id})}"
+                               th:text="|${qna.title}${qna.deleted ? ' (삭제됨)' : ''}|"
+                               class="text-sm text-gray-700 hover:underline"></a>
+                        </td>
+                        <td th:text="${qna.isAnswered ? '답변 완료' : '답변 대기'}"
+                            class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"></td>
+                        <td th:text="${qna.nickname != null ? qna.nickname : qna.name}"
+                            class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"></td>
+                        <td th:text="${qna.createdAt}"
+                            class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- 페이징 -->
+            <div class="flex justify-center mt-6">
+                <nav id="pagination"
+                     th:data-current-page="${currentPage}"
+                     th:data-total-pages="${totalPages}"
+                     class="inline-flex -space-x-px">
+                </nav>
+            </div>
         </div>
     </div>
+
     <script>
         document.addEventListener("DOMContentLoaded", () => {
-            const cat = document.querySelector("#category");
-            const selectedCategory = cat.value;
-            const nav = document.querySelector("#pagination");
-            const current = Number(nav.dataset.currentPage);
-            const total = Number(nav.dataset.totalPages);
+          const categorySelect = document.getElementById("categorySelect");
+          const statusSelect   = document.getElementById("statusSelect");
+          const keywordInput   = document.getElementById("keywordInput");
+          const searchBtn      = document.getElementById("searchBtn");
+          const nav            = document.getElementById("pagination");
+          const current        = Number(nav.dataset.currentPage);
+          const total          = Number(nav.dataset.totalPages);
 
-            function pageBtn(label, page, option = {}) {
-                const {active = false, disabled = false, rounded = "", category = ""} = option;
-                const a = document.createElement("a");
+          // URL 빌더
+          function buildUrl(page = 1) {
+            const params = new URLSearchParams();
+            if (categorySelect.value) params.set("category", categorySelect.value);
+            if (statusSelect.value)   params.set("status",   statusSelect.value);
+            if (keywordInput.value.trim()) params.set("keyword", keywordInput.value.trim());
+            params.set("page", page);
+            return `/admin/qna?${params.toString()}`;
+          }
 
-                if(typeof label === "number") {
-                    a.textContent = label;
-                }else {
-                    const i = document.createElement("i");
-                    i.className = label === "left" ? "fa-solid fa-angle-left" : "fa-solid fa-angle-right";
-                    a.appendChild(i)
-                }
+          // 필터 즉시 적용
+          categorySelect.addEventListener("change", () => {
+            window.location.href = buildUrl(1);
+          });
+          statusSelect.addEventListener("change", () => {
+            window.location.href = buildUrl(1);
+          });
 
-                a.className = "px-3 py-1 border";
+          // 제목 검색 버튼
+          searchBtn.addEventListener("click", () => {
+            if (!keywordInput.value.trim()) return;
+            window.location.href = buildUrl(1);
+          });
 
-                if(active) {
-                    a.classList.add("bg-blue-500", "text-white", "border-blue-500");
-                }else {
-                    a.classList.add("bg-white", "text-gray-500", "border-gray-300", "hover:bg-gray-100");
-                }
-
-                if(disabled) {
-                    a.href = "javascript:;";
-                    a.classList.add("cursor-not-allowed", "opacity-50");
-                }else {
-                    if(category) {
-                        a.href = `/admin/qna?category=${category}&page=${page}`;
-                    }else {
-                        a.href = `/admin/qna?page=${page}`;
-                    }
-                }
-
-                if(rounded === "left") a.classList.add("rounded-l-lg");
-                if(rounded === "right") a.classList.add("rounded-r-lg");
-
-                return a;
+          // 페이징 버튼 렌더링
+          function pageBtn(label, page, opts = {}) {
+            const { active = false, disabled = false, rounded = "" } = opts;
+            const a = document.createElement("a");
+            if (typeof label === "number") a.textContent = label;
+            else {
+              const i = document.createElement("i");
+              i.className = label === "left"
+                ? "fa-solid fa-angle-left"
+                : "fa-solid fa-angle-right";
+              a.appendChild(i);
             }
-
-            cat.addEventListener("change", async (e) => {
-                const selected = e.target.value;
-
-                window.location.href = `/admin/qna?category=${selected}&page=1`;
-            })
-
-            nav.appendChild(pageBtn("left", current-1, {
-                disabled: current === 1,
-                rounded: "left",
-                category: selectedCategory
-            }));
-
-            for(let p=1; p<=total; p++) {
-                nav.appendChild(pageBtn(p, p, {
-                    active: p === current,
-                    category: selectedCategory
-                }));
+            a.className = "px-3 py-1 border";
+            if (active) a.classList.add("bg-blue-500","text-white","border-blue-500");
+            else        a.classList.add("bg-white","text-gray-500","border-gray-300","hover:bg-gray-100");
+            if (disabled) {
+              a.href = "javascript:;";
+              a.classList.add("cursor-not-allowed","opacity-50");
+            } else {
+              a.href = buildUrl(page);
             }
+            if (rounded === "left")  a.classList.add("rounded-l-lg");
+            if (rounded === "right") a.classList.add("rounded-r-lg");
+            return a;
+          }
 
-            nav.appendChild(pageBtn("right", current+1, {
-                disabled: current === total,
-                rounded: "right",
-                category: selectedCategory
-            }));
-        })
+          // Prev
+          nav.appendChild(pageBtn("left", current - 1, {
+            disabled: current === 1, rounded: "left"
+          }));
+          // 페이지 번호
+          for (let p = 1; p <= total; p++) {
+            nav.appendChild(pageBtn(p, p, { active: p === current }));
+          }
+          // Next
+          nav.appendChild(pageBtn("right", current + 1, {
+            disabled: current === total, rounded: "right"
+          }));
+        });
     </script>
-</div>
-    </div>
 </th:block>
 </html>

--- a/src/main/resources/templates/community/allPostsDetail.html
+++ b/src/main/resources/templates/community/allPostsDetail.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{layout/default_layout}"
-      th:with="userService=${@userService}">
+      layout:decorate="~{layout/default_layout}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -19,15 +18,11 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-gray-700 mb-6">
             <p><span class="font-medium">카테고리:</span> <span th:text="${board.category2}"></span></p>
             <p><span class="font-medium">조회수:</span>   <span th:text="${board.views}"></span></p>
-            <!-- usersId null 체크 후 닉네임 또는 '손님' -->
             <p><span class="font-medium">작성자:</span>
-                <span th:text="${board.usersId != null
-                    ? userService.getMemberEntityById(board.usersId).nickname
-                    : '손님'}">
-                </span>
-            </p>
+                <span th:text="${authorNickname}">닉네임</span></p>
             <p><span class="font-medium">작성일:</span>
                 <span th:text="${#temporals.format(board.createdAt,'yyyy.MM.dd HH:mm')}"></span>
+                <br>
             </p>
         </div>
 
@@ -37,20 +32,72 @@
 
         <h3 class="text-2xl font-semibold text-gray-800 mb-4">댓글</h3>
         <div class="space-y-4 mb-6">
-            <div th:each="c : ${commentsPage.content}" class="border-b pb-2">
-                <p>
-                    <strong class="text-[#7CA48C]"
-                            th:text="${c.usersId != null
-                                ? userService.getMemberEntityById(c.usersId).nickname
-                                : '손님'}">
-                    </strong>:
-                    <span th:text="${c.content}"></span>
-                    <small class="text-gray-500 ml-2"
-                           th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}"></small>
-                </p>
+            <div th:each="c,stat : ${commentsPage.content}" class="bg-white p-4 rounded-lg shadow-sm hover:shadow-md transition-shadow">
+                <div class="flex items-start justify-between">
+                    <!-- 좌측: 작성자·내용·시간 -->
+                    <div class="flex-1">
+                        <p class="text-gray-800 break-words">
+                            <span class="font-semibold text-[#7CA48C]" th:text="${commentNicknames[stat.index]}">닉네임</span>
+                            <span>·</span>
+                            <span class="text-gray-600" th:text="${c.content}">댓글 내용</span>
+                        </p>
+                        <p class="text-xs text-gray-400 mt-1" th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">
+                            2025.06.27 19:13
+                        </p>
+                    </div>
+
+                    <!-- 우측: 내 댓글일 때만 버튼 그룹 -->
+                    <div th:if="${c.usersId eq currentUserId}" class="ml-4 flex-shrink-0 flex space-x-2">
+                        <!-- 수정 버튼 -->
+                        <button type="button"
+                                class="flex items-center space-x-1 text-sm text-blue-600 hover:text-blue-800"
+                                th:attr="data-comment-id=${c.id}, data-comment-content=${c.content}"
+                                onclick="openEditModal(
+                          this.getAttribute('data-comment-id'),
+                          this.getAttribute('data-comment-content')
+                        )">
+                            <i class="fas fa-pencil-alt"></i>
+                            <span>수정</span>
+                        </button>
+                        <!-- 삭제 버튼 -->
+                        <form th:action="@{/community/allPosts/{b}/comments/{c}/delete(
+                          b=${board.communityId},c=${c.id})}"
+                              method="post"
+                              class="flex items-center space-x-1"
+                              onsubmit="return confirm('정말 삭제하시겠습니까?');">
+                            <i class="fas fa-trash-alt text-red-500"></i>
+                            <button type="submit" class="text-sm text-red-500 hover:text-red-700">
+                                삭제
+                            </button>
+                        </form>
+                    </div>
+                </div>
             </div>
         </div>
 
+        <!-- 수정 모달 -->
+        <div id="editModal"
+             class="fixed inset-0 flex items-center justify-center
+                bg-black bg-opacity-50 hidden">
+            <div class="bg-white rounded-lg p-6 w-2/3 max-w-lg">
+                <h2 class="text-xl font-semibold mb-4">댓글 수정</h2>
+                <form id="editCommentForm" method="post" class="space-y-4">
+          <textarea name="content" id="editContent" rows="4"
+                    class="w-full border rounded px-3 py-2
+                           focus:outline-none focus:ring-2 focus:ring-indigo-500"></textarea>
+                    <div class="flex justify-end space-x-2">
+                        <button type="button" onclick="closeModal()"
+                                class="px-4 py-2 border rounded hover:bg-gray-100">취소</button>
+                        <button type="submit"
+                                class="px-4 py-2 bg-[#7CA48C] text-white rounded hover:opacity-90">
+                            저장
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <!-- 댓글 페이징 -->
         <nav th:if="${commentsPage.totalElements > 0}" class="flex justify-center space-x-2 mb-6">
             <span th:if="${commentsPage.hasPrevious()}">
                 <a th:href="@{/community/allPosts/{id}(id=${board.communityId},commentPage=${commentsPage.number-1})}"
@@ -83,5 +130,28 @@
 
         <a th:href="@{/community/allPosts/list}" class="inline-block text-[#E3A67A] hover:underline">◀ 목록으로 돌아가기</a>
     </div>
+
+    <script th:inline="javascript">
+
+        // Thymeleaf → JS 변수
+        var boardId = /*[[${board.communityId}]]*/ 0;
+
+        function openEditModal(commentId, content) {
+          // 1) textarea 채우기
+          document.getElementById('editContent').value = content;
+          // 2) form.action 조립
+          document.getElementById('editCommentForm').action
+            = '/community/allPosts/' + boardId
+            + '/comments/' + commentId;
+          // 3) 모달 열기
+          document.getElementById('editModal').classList.remove('hidden');
+        }
+
+        function closeModal() {
+          document.getElementById('editModal').classList.add('hidden');
+        }
+
+    </script>
+
 </th:block>
 </html>

--- a/src/main/resources/templates/community/announcementDetail.html
+++ b/src/main/resources/templates/community/announcementDetail.html
@@ -2,8 +2,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{layout/default_layout}"
-      th:with="userService=${@userService}">
+      layout:decorate="~{layout/default_layout}">
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -34,14 +33,68 @@
 
         <h3 class="text-2xl font-semibold text-gray-800 mb-4">댓글</h3>
         <div class="space-y-4 mb-6">
-            <div th:each="c, stat : ${commentsPage.content}" class="border-b pb-2">
-                <p>
-                    <strong class="text-[#7CA48C]"
-                            th:text="${commentNicknames[stat.index]}">닉네임</strong>:
-                    <span th:text="${c.content}">댓글 내용</span>
-                    <small class="text-gray-500 ml-2"
-                           th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">시간</small>
-                </p>
+            <div th:each="c,stat : ${commentsPage.content}" class="bg-white p-4 rounded-lg shadow-sm hover:shadow-md transition-shadow">
+                <div class="flex items-start justify-between">
+                    <!-- 좌측: 작성자·내용·시간 -->
+                    <div class="flex-1">
+                        <p class="text-gray-800 break-words">
+                            <span class="font-semibold text-[#7CA48C]" th:text="${commentNicknames[stat.index]}">닉네임</span>
+                            <span>·</span>
+                            <span class="text-gray-600" th:text="${c.content}">댓글 내용</span>
+                        </p>
+                        <p class="text-xs text-gray-400 mt-1" th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">
+                            2025.06.27 19:13
+                        </p>
+                    </div>
+
+                    <!-- 우측: 내 댓글일 때만 버튼 그룹 -->
+                    <div th:if="${c.usersId eq currentUserId}" class="ml-4 flex-shrink-0 flex space-x-2">
+                        <!-- 수정 버튼 -->
+                        <button type="button"
+                                class="flex items-center space-x-1 text-sm text-blue-600 hover:text-blue-800"
+                                th:attr="data-comment-id=${c.id}, data-comment-content=${c.content}"
+                                onclick="openEditModal(
+                          this.getAttribute('data-comment-id'),
+                          this.getAttribute('data-comment-content')
+                        )">
+                            <i class="fas fa-pencil-alt"></i>
+                            <span>수정</span>
+                        </button>
+                        <!-- 삭제 버튼 -->
+                        <form th:action="@{/community/announcement/{b}/comments/{c}/delete(
+                          b=${board.communityId},c=${c.id})}"
+                              method="post"
+                              class="flex items-center space-x-1"
+                              onsubmit="return confirm('정말 삭제하시겠습니까?');">
+                            <i class="fas fa-trash-alt text-red-500"></i>
+                            <button type="submit" class="text-sm text-red-500 hover:text-red-700">
+                                삭제
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 수정 모달 -->
+        <div id="editModal"
+             class="fixed inset-0 flex items-center justify-center
+                bg-black bg-opacity-50 hidden">
+            <div class="bg-white rounded-lg p-6 w-2/3 max-w-lg">
+                <h2 class="text-xl font-semibold mb-4">댓글 수정</h2>
+                <form id="editCommentForm" method="post" class="space-y-4">
+          <textarea name="content" id="editContent" rows="4"
+                    class="w-full border rounded px-3 py-2
+                           focus:outline-none focus:ring-2 focus:ring-indigo-500"></textarea>
+                    <div class="flex justify-end space-x-2">
+                        <button type="button" onclick="closeModal()"
+                                class="px-4 py-2 border rounded hover:bg-gray-100">취소</button>
+                        <button type="submit"
+                                class="px-4 py-2 bg-[#7CA48C] text-white rounded hover:opacity-90">
+                            저장
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
 
@@ -95,5 +148,28 @@
            class="inline-block text-[#E3A67A] hover:underline">◀ 목록으로 돌아가기</a>
 
     </div>
+
+    <script th:inline="javascript">
+
+        // Thymeleaf → JS 변수
+        var boardId = /*[[${board.communityId}]]*/ 0;
+
+        function openEditModal(commentId, content) {
+          // 1) textarea 채우기
+          document.getElementById('editContent').value = content;
+          // 2) form.action 조립
+          document.getElementById('editCommentForm').action
+            = '/community/announcement/' + boardId
+            + '/comments/' + commentId;
+          // 3) 모달 열기
+          document.getElementById('editModal').classList.remove('hidden');
+        }
+
+        function closeModal() {
+          document.getElementById('editModal').classList.add('hidden');
+        }
+
+    </script>
+
 </th:block>
 </html>

--- a/src/main/resources/templates/community/parentingDetail.html
+++ b/src/main/resources/templates/community/parentingDetail.html
@@ -31,14 +31,68 @@
         <!-- 댓글 섹션 -->
         <h3 class="text-2xl font-semibold text-gray-800 mb-4">댓글</h3>
         <div class="space-y-4 mb-6">
-            <div th:each="c, stat : ${commentsPage.content}" class="border-b pb-2">
-                <p>
-                    <strong class="text-[#7CA48C]"
-                            th:text="${commentNicknames[stat.index]}">닉네임</strong>:
-                    <span th:text="${c.content}">댓글 내용</span>
-                    <small class="text-gray-500 ml-2"
-                           th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">시간</small>
-                </p>
+            <div th:each="c,stat : ${commentsPage.content}" class="bg-white p-4 rounded-lg shadow-sm hover:shadow-md transition-shadow">
+                <div class="flex items-start justify-between">
+                    <!-- 좌측: 작성자·내용·시간 -->
+                    <div class="flex-1">
+                        <p class="text-gray-800 break-words">
+                            <span class="font-semibold text-[#7CA48C]" th:text="${commentNicknames[stat.index]}">닉네임</span>
+                            <span>·</span>
+                            <span class="text-gray-600" th:text="${c.content}">댓글 내용</span>
+                        </p>
+                        <p class="text-xs text-gray-400 mt-1" th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">
+                            2025.06.27 19:13
+                        </p>
+                    </div>
+
+                    <!-- 우측: 내 댓글일 때만 버튼 그룹 -->
+                    <div th:if="${c.usersId eq currentUserId}" class="ml-4 flex-shrink-0 flex space-x-2">
+                        <!-- 수정 버튼 -->
+                        <button type="button"
+                                class="flex items-center space-x-1 text-sm text-blue-600 hover:text-blue-800"
+                                th:attr="data-comment-id=${c.id}, data-comment-content=${c.content}"
+                                onclick="openEditModal(
+                          this.getAttribute('data-comment-id'),
+                          this.getAttribute('data-comment-content')
+                        )">
+                            <i class="fas fa-pencil-alt"></i>
+                            <span>수정</span>
+                        </button>
+                        <!-- 삭제 버튼 -->
+                        <form th:action="@{/community/parenting/{b}/comments/{c}/delete(
+                          b=${board.communityId},c=${c.id})}"
+                              method="post"
+                              class="flex items-center space-x-1"
+                              onsubmit="return confirm('정말 삭제하시겠습니까?');">
+                            <i class="fas fa-trash-alt text-red-500"></i>
+                            <button type="submit" class="text-sm text-red-500 hover:text-red-700">
+                                삭제
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 수정 모달 -->
+        <div id="editModal"
+             class="fixed inset-0 flex items-center justify-center
+                bg-black bg-opacity-50 hidden">
+            <div class="bg-white rounded-lg p-6 w-2/3 max-w-lg">
+                <h2 class="text-xl font-semibold mb-4">댓글 수정</h2>
+                <form id="editCommentForm" method="post" class="space-y-4">
+          <textarea name="content" id="editContent" rows="4"
+                    class="w-full border rounded px-3 py-2
+                           focus:outline-none focus:ring-2 focus:ring-indigo-500"></textarea>
+                    <div class="flex justify-end space-x-2">
+                        <button type="button" onclick="closeModal()"
+                                class="px-4 py-2 border rounded hover:bg-gray-100">취소</button>
+                        <button type="submit"
+                                class="px-4 py-2 bg-[#7CA48C] text-white rounded hover:opacity-90">
+                            저장
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
 
@@ -92,5 +146,28 @@
         <a th:href="@{/community/parenting/list}"
            class="inline-block text-[#E3A67A] hover:underline">◀ 목록으로 돌아가기</a>
     </div>
+
+    <script th:inline="javascript">
+
+        // Thymeleaf → JS 변수
+        var boardId = /*[[${board.communityId}]]*/ 0;
+
+        function openEditModal(commentId, content) {
+          // 1) textarea 채우기
+          document.getElementById('editContent').value = content;
+          // 2) form.action 조립
+          document.getElementById('editCommentForm').action
+            = '/community/parenting/' + boardId
+            + '/comments/' + commentId;
+          // 3) 모달 열기
+          document.getElementById('editModal').classList.remove('hidden');
+        }
+
+        function closeModal() {
+          document.getElementById('editModal').classList.add('hidden');
+        }
+
+    </script>
+
 </th:block>
 </html>

--- a/src/main/resources/templates/community/policyDetail.html
+++ b/src/main/resources/templates/community/policyDetail.html
@@ -36,33 +36,46 @@
         <!-- 댓글 섹션 -->
         <h3 class="text-2xl font-semibold text-gray-800 mb-4">댓글</h3>
         <div class="space-y-4 mb-6">
-            <div th:each="c,stat : ${commentsPage.content}" class="border-b pb-2">
-                <p>
-                    <strong class="text-[#7CA48C]"
-                            th:text="${commentNicknames[stat.index]}">닉네임</strong>:
-                    <span th:text="${c.content}">댓글 내용</span>
-                    <small class="text-gray-500 ml-2"
-                           th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">시간</small>
+            <div th:each="c,stat : ${commentsPage.content}" class="bg-white p-4 rounded-lg shadow-sm hover:shadow-md transition-shadow">
+                <div class="flex items-start justify-between">
+                    <!-- 좌측: 작성자·내용·시간 -->
+                    <div class="flex-1">
+                        <p class="text-gray-800 break-words">
+                            <span class="font-semibold text-[#7CA48C]" th:text="${commentNicknames[stat.index]}">닉네임</span>
+                            <span>·</span>
+                            <span class="text-gray-600" th:text="${c.content}">댓글 내용</span>
+                        </p>
+                        <p class="text-xs text-gray-400 mt-1" th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">
+                            2025.06.27 19:13
+                        </p>
+                    </div>
 
-                    <!-- ★★ 내 댓글에만 수정/삭제 버튼 -->
-                    <span th:if="${currentUserId != null
-                        and currentUserId == commentUserIds[stat.index]}"
-                          class="ml-4 space-x-2">
-            <!-- 수정 (모달 열기) -->
-            <a href="#"
-               class="text-blue-600 hover:underline"
-               onclick="openEditModal([[${c.id}]], '[[${c.content}]]')">수정</a>
-                        <!-- 삭제 -->
-            <form th:action="@{/community/policy/{boardId}/comments/{commentId}/delete(
-                                boardId=${board.communityId},
-                                commentId=${c.id})}"
-                  method="post" style="display:inline"
-                  onsubmit="return confirm('정말 삭제하시겠습니까?');">
-              <button type="submit"
-                      class="text-red-600 hover:underline">삭제</button>
-            </form>
-          </span>
-                </p>
+                    <!-- 우측: 내 댓글일 때만 버튼 그룹 -->
+                    <div th:if="${c.usersId eq currentUserId}" class="ml-4 flex-shrink-0 flex space-x-2">
+                        <!-- 수정 버튼 -->
+                        <button type="button"
+                                class="flex items-center space-x-1 text-sm text-blue-600 hover:text-blue-800"
+                                th:attr="data-comment-id=${c.id}, data-comment-content=${c.content}"
+                                onclick="openEditModal(
+                          this.getAttribute('data-comment-id'),
+                          this.getAttribute('data-comment-content')
+                        )">
+                            <i class="fas fa-pencil-alt"></i>
+                            <span>수정</span>
+                        </button>
+                        <!-- 삭제 버튼 -->
+                        <form th:action="@{/community/policy/{b}/comments/{c}/delete(
+                          b=${board.communityId},c=${c.id})}"
+                              method="post"
+                              class="flex items-center space-x-1"
+                              onsubmit="return confirm('정말 삭제하시겠습니까?');">
+                            <i class="fas fa-trash-alt text-red-500"></i>
+                            <button type="submit" class="text-sm text-red-500 hover:text-red-700">
+                                삭제
+                            </button>
+                        </form>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -88,21 +101,79 @@
             </div>
         </div>
 
-        <!-- (이하 댓글 페이징 / 댓글등록 폼 / 본문 수정·삭제 버튼 생략) -->
+        <!-- 댓글 페이징 -->
+        <nav th:if="${commentsPage.totalElements > 0}" class="flex justify-center space-x-2 mb-6">
+            <span th:if="${commentsPage.hasPrevious()}">
+                <a th:href="@{/community/policy/{id}(id=${board.communityId},commentPage=${commentsPage.number-1})}"
+                   class="px-3 py-1 bg-gray-200 text-[#E3A67A] rounded hover:bg-gray-300">&lt; 이전</a>
+            </span>
+            <span th:each="i : ${#numbers.sequence(0,commentsPage.totalPages-1)}">
+                <a th:href="@{/community/policy/{id}(id=${board.communityId},commentPage=${i})}"
+                   th:text="${i+1}"
+                   th:classappend="${i == commentsPage.number}
+                                   ? ' bg-[#E3A67A] text-white'
+                                   : ' bg-gray-200 text-[#E3A67A]'"
+                   class="px-3 py-1 rounded hover:bg-[#E3A67A] hover:text-white"></a>
+            </span>
+            <span th:if="${commentsPage.hasNext()}">
+                <a th:href="@{/community/policy/{id}(id=${board.communityId},commentPage=${commentsPage.number+1})}"
+                   class="px-3 py-1 bg-gray-200 text-[#E3A67A] rounded hover:bg-gray-300">다음 &gt;</a>
+            </span>
+        </nav>
+
+        <!-- 댓글 입력 폼 -->
+        <form th:action="@{/community/policy/{id}/comments(id=${board.communityId})}" method="post" class="mb-6">
+            <textarea name="content" rows="3" placeholder="댓글을 입력하세요."
+                      class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      required></textarea>
+            <button type="submit"
+                    class="mt-2 bg-[#E3A67A] text-white font-semibold px-5 py-2 rounded hover:opacity-90">
+                등록하기
+            </button>
+        </form>
+
+        <!-- 수정/삭제 버튼: 작성자 본인만 -->
+        <div class="flex gap-4 mb-6"
+             th:if="${currentUserId != null and currentUserId == board.usersId}">
+            <a th:href="@{/community/policy/{id}/edit(id=${board.communityId})}"
+               class="inline-flex items-center bg-[#7CA48C] text-white px-5 py-2 rounded hover:opacity-90">
+                <i class="fas fa-edit mr-2"></i>수정
+            </a>
+            <form th:action="@{/community/policy/{id}/delete(id=${board.communityId})}" method="post"
+                  onsubmit="return confirm('정말 삭제하시겠습니까?');">
+                <button type="submit"
+                        class="inline-flex items-center bg-red-500 text-white px-5 py-2 rounded hover:bg-red-600">
+                    <i class="fas fa-trash mr-2"></i>삭제
+                </button>
+            </form>
+        </div>
+
+        <a th:href="@{/community/policy/list}"
+           class="inline-block text-[#E3A67A] hover:underline">◀ 목록으로 돌아가기</a>
 
     </div>
 
-    <!-- 모달 스크립트: th:inline 필수 -->
     <script th:inline="javascript">
+
+        // Thymeleaf → JS 변수
+        var boardId = /*[[${board.communityId}]]*/ 0;
+
         function openEditModal(commentId, content) {
+          // 1) textarea 채우기
           document.getElementById('editContent').value = content;
-          const form = document.getElementById('editCommentForm');
-          form.action = /*[[@{'/community/policy/' + ${board.communityId} + '/comments/' + ${commentId}}]]*/'';
+          // 2) form.action 조립
+          document.getElementById('editCommentForm').action
+            = '/community/policy/' + boardId
+            + '/comments/' + commentId;
+          // 3) 모달 열기
           document.getElementById('editModal').classList.remove('hidden');
         }
+
         function closeModal() {
           document.getElementById('editModal').classList.add('hidden');
         }
+
     </script>
+
 </th:block>
 </html>

--- a/src/main/resources/templates/dailySurvey.html
+++ b/src/main/resources/templates/dailySurvey.html
@@ -21,13 +21,30 @@
         <!-- 1) 자녀 선택 -->
         <label for="childSelect" class="block mb-2 font-semibold">자녀 선택:</label>
         <select id="childSelect" class="border p-2 rounded mb-4">
-            <option value="">-- 자녀를 선택하세요 --</option>
+
+            <!-- 자녀가 한 명도 없으면 -->
+            <option th:if="${children.empty}"
+                    value=""
+                    disabled
+                    selected>
+                등록된 자녀가 없습니다.
+            </option>
+
+            <!-- 자녀가 있으면 -->
+            <option th:if="${!children.empty}"
+                    value=""
+                    th:selected="${selectedChildId == null}">
+                -- 자녀를 선택하세요 --
+            </option>
+
             <option th:each="c : ${children}"
                     th:value="${c.id}"
                     th:selected="${c.id == selectedChildId}"
                     th:text="${c.name + ' (' + c.ageDisplay + ')'}">
             </option>
         </select>
+
+        <a href="/member/child" class="text-sm text-blue-600 px-4 hover:underline">+ 자녀 추가하기</a>
 
         <!-- 2) 이미 작성했으면 이 메시지만 보이고, 나머지는 숨김 -->
         <div id="alreadyMessage"

--- a/src/main/resources/templates/fragments/managerHeader.html
+++ b/src/main/resources/templates/fragments/managerHeader.html
@@ -42,9 +42,9 @@
             <div class="container mx-auto flex justify-center items-center py-1 px-8">
                 <ul class="flex space-x-8">
                     <li class="relative group">
-                        <a href="/manager/home" class="block px-1 py-4 text-md hover:text-[#FEF9F3] whitespace-nowrap">홈</a>
+                        <a href="/manager/main" class="block px-1 py-4 text-md hover:text-[#FEF9F3] whitespace-nowrap">홈</a>
                         <ul class="absolute top-full left-1/2 -translate-x-1/2 hidden group-hover:block hover:block bg-black bg-opacity-70 text-white shadow-lg mt-0.5 min-w-[180px] text-center z-50 py-2">
-                            <li><a href="/manager/home" class="block px-4 py-2 hover:text-gray-300">담당자 홈페이지</a></li>
+                            <li><a href="/manager/main" class="block px-4 py-2 hover:text-gray-300">담당자 홈페이지</a></li>
                             <li><a href="/" class="block px-4 py-2 hover:text-gray-300">메인 홈페이지</a></li>
                         </ul>
                     </li>

--- a/src/main/resources/templates/manager/surveys/groupForm.html
+++ b/src/main/resources/templates/manager/surveys/groupForm.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/admin_layout}">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/managerLayout}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,8 +17,8 @@
             class="text-2xl font-semibold mb-6"></h1>
 
         <form th:action="${survey.id} == null
-                         ? @{/admin/manager/surveys/group}
-                         : @{/admin/manager/surveys/group/{id}(id=${survey.id})}"
+                         ? @{/manager/surveys/group}
+                         : @{/manager/surveys/group/{id}(id=${survey.id})}"
               method="post" class="space-y-4 max-w-lg">
             <!-- 연령대 -->
             <label class="block">

--- a/src/main/resources/templates/manager/surveys/groupList.html
+++ b/src/main/resources/templates/manager/surveys/groupList.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/admin_layout}">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/managerLayout}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,7 +13,7 @@
     <div class="max-w-7xl mx-auto bg-white shadow p-6 mt-8 mb-8 rounded">
         <h1 class="text-2xl font-semibold mb-4">담당자 - 그룹 문진 목록</h1>
 
-        <form th:action="@{/admin/manager/surveys/group}" method="get" class="flex gap-4 items-center mb-6">
+        <form th:action="@{/manager/surveys/group}" method="get" class="flex gap-4 items-center mb-6">
             <label class="flex items-center gap-2">
                 <span>연령대:</span>
                 <select name="ageGroup" class="border p-2 rounded">
@@ -48,7 +48,7 @@
                 검색
             </button>
 
-            <a th:href="@{/admin/manager/surveys/group/new}"
+            <a th:href="@{/manager/surveys/group/new}"
                class="bg-green-600 text-white px-4 py-1 rounded">
                 그룹 문진 추가
             </a>
@@ -65,14 +65,21 @@
             </tr>
             </thead>
             <tbody>
+
+            <tr th:if="${surveys.totalElements == 0}">
+                <td class="border p-2 text-center" colspan="4">
+                    검색 결과가 없습니다.
+                </td>
+            </tr>
+
             <tr th:each="s : ${surveys}" class="hover:bg-gray-50">
                 <td class="border p-2" th:text="${s.ageGroup.displayName}"></td>
                 <td class="border p-2" th:text="${s.category.displayName}"></td>
                 <td class="border p-2" th:text="${s.question}"></td>
                 <td class="border p-2">
-                    <a th:href="@{/admin/manager/surveys/group/{id}/edit(id=${s.id})}"
+                    <a th:href="@{/manager/surveys/group/{id}/edit(id=${s.id})}"
                        class="text-blue-600 mr-3 hover:underline">수정</a>
-                    <form th:action="@{/admin/manager/surveys/group/{id}/delete(id=${s.id})}"
+                    <form th:action="@{/manager/surveys/group/{id}/delete(id=${s.id})}"
                           method="post" class="inline"
                           onsubmit="return confirm('삭제하시겠습니까?');">
                         <button type="submit" class="text-red-600 hover:underline">
@@ -87,7 +94,7 @@
         <!-- 페이징 내비 -->
         <div class="mt-4 flex justify-center gap-2">
             <a th:if="${surveys.hasPrevious()}"
-               th:href="@{/admin/manager/surveys/group(
+               th:href="@{/manager/surveys/group(
                      ageGroup=${ageGroup},
                      category=${category},
                      page=${surveys.number-1})}"
@@ -96,7 +103,7 @@
             <span th:each="i : ${#numbers.sequence(0, surveys.totalPages-1)}"
                   class="px-2"
                   th:classappend="${i == surveys.number} ? 'font-bold underline'">
-                <a th:href="@{/admin/manager/surveys/group(
+                <a th:href="@{/manager/surveys/group(
                              ageGroup=${ageGroup},
                              category=${category},
                              page=${i})}"
@@ -104,7 +111,7 @@
             </span>
 
             <a th:if="${surveys.hasNext()}"
-               th:href="@{/admin/manager/surveys/group(
+               th:href="@{/manager/surveys/group(
                      ageGroup=${ageGroup},
                      category=${category},
                      page=${surveys.number+1})}"

--- a/src/main/resources/templates/survey/dailyAnswerHistory.html
+++ b/src/main/resources/templates/survey/dailyAnswerHistory.html
@@ -23,13 +23,31 @@
         <div class="mb-6">
             <label for="childSelect" class="font-semibold mr-2">자녀 선택:</label>
             <select id="childSelect" class="border p-2 rounded w-64">
-                <option value="" th:if="${childId == null}" selected disabled>자녀를 선택하세요</option>
+
+                <!-- 자녀가 한 명도 없으면 -->
+                <option th:if="${children.empty}"
+                        value=""
+                        disabled
+                        selected>
+                    등록된 자녀가 없습니다.
+                </option>
+
+                <!-- 자녀가 있으면 -->
+                <option th:if="${!children.empty}"
+                        value=""
+                        th:selected="${selectedChildId == null}">
+                    -- 자녀를 선택하세요 --
+                </option>
+
                 <option th:each="c : ${children}"
                         th:value="${c.id}"
                         th:selected="${c.id == childId}"
                         th:text="${c.name + ' (' + c.nickname + ')'}">
                 </option>
             </select>
+
+            <a href="/member/child" class="px-4 text-sm text-blue-600 hover:underline">+ 자녀 추가하기</a>
+
         </div>
 
         <!-- 2) 자녀 정보 -->
@@ -122,7 +140,7 @@
             answerList.innerHTML = "";
 
             if (!hist.length) {
-              answerList.innerHTML = `<p class="text-gray-500">답변 이력이 없습니다.</p>`;
+              answerList.innerHTML = `<p class="text-gray-500 text-center italic">답변 이력이 없습니다.</p>`;
               return;
             }
 

--- a/src/main/resources/templates/survey/groupAnswerHistory.html
+++ b/src/main/resources/templates/survey/groupAnswerHistory.html
@@ -17,12 +17,30 @@
         <div class="mb-4">
             <label for="childSelect" class="font-semibold mr-2">자녀 선택:</label>
             <select id="childSelect" class="border p-2 rounded w-64">
-                <option value="" disabled selected>자녀를 선택하세요</option>
+
+                <!-- 자녀가 한 명도 없으면 -->
+                <option th:if="${children.empty}"
+                        value=""
+                        disabled
+                        selected>
+                    등록된 자녀가 없습니다.
+                </option>
+
+                <!-- 자녀가 있으면 -->
+                <option th:if="${!children.empty}"
+                        value=""
+                        th:selected="${selectedChildId == null}">
+                    -- 자녀를 선택하세요 --
+                </option>
+
                 <option th:each="c : ${children}"
                         th:value="${c.id}"
                         th:text="${c.name + ' (' + c.nickname + ')'}">
                 </option>
             </select>
+
+            <a href="/member/child" class="text-sm text-blue-600 px-4 hover:underline">+ 자녀 추가하기</a>
+
         </div>
 
         <!-- 2) 자녀 정보 -->
@@ -140,7 +158,7 @@
               lastFetched = data;
               list.innerHTML = '';
               if (data.length === 0) {
-                list.innerHTML = `<p class="text-gray-500">답변 이력이 없습니다.</p>`;
+                list.innerHTML = `<p class="text-gray-500 text-center italic">답변 이력이 없습니다.</p>`;
                 return;
               }
 

--- a/src/main/resources/templates/survey/recordAnswerForm.html
+++ b/src/main/resources/templates/survey/recordAnswerForm.html
@@ -97,7 +97,7 @@
                 </option>
             </select>
             <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">선택</button>
-            <a href="/mypage/children" class="text-sm text-blue-600 hover:underline">+ 자녀 추가하기</a>
+            <a href="/member/child" class="text-sm text-blue-600 hover:underline">+ 자녀 추가하기</a>
         </form>
 
         <div th:if="${selectedChild != null}" class="mb-6 p-4 border rounded bg-gray-50">

--- a/src/main/resources/templates/survey/recordAnswerHistory.html
+++ b/src/main/resources/templates/survey/recordAnswerHistory.html
@@ -39,9 +39,27 @@
         <div class="mb-6">
             <label for="childSelect" class="font-semibold mr-2">자녀 선택:</label>
             <select id="childSelect" class="border p-2 rounded w-64">
-                <option value="" disabled selected>자녀를 선택하세요</option>
+
+                <!-- 자녀가 한 명도 없으면 -->
+                <option th:if="${children.empty}"
+                        value=""
+                        disabled
+                        selected>
+                    등록된 자녀가 없습니다.
+                </option>
+
+                <!-- 자녀가 있으면 -->
+                <option th:if="${!children.empty}"
+                        value=""
+                        th:selected="${selectedChildId == null}">
+                    -- 자녀를 선택하세요 --
+                </option>
+
                 <option th:each="child : ${children}" th:value="${child.id}" th:text="${child.name}"></option>
             </select>
+
+            <a href="/member/child" class="text-sm text-blue-600 px-4 hover:underline">+ 자녀 추가하기</a>
+
         </div>
 
         <div id="answerListContainer" class="hidden">

--- a/src/main/resources/templates/survey/specialAnswerHistory.html
+++ b/src/main/resources/templates/survey/specialAnswerHistory.html
@@ -16,12 +16,30 @@
         <div class="mb-4">
             <label for="childSelect" class="font-semibold mr-2">자녀 선택:</label>
             <select id="childSelect" class="border p-2 rounded w-64">
-                <option value="" disabled selected>자녀를 선택하세요</option>
+
+                <!-- 자녀가 한 명도 없으면 -->
+                <option th:if="${children.empty}"
+                        value=""
+                        disabled
+                        selected>
+                    등록된 자녀가 없습니다.
+                </option>
+
+                <!-- 자녀가 있으면 -->
+                <option th:if="${!children.empty}"
+                        value=""
+                        th:selected="${selectedChildId == null}">
+                    -- 자녀를 선택하세요 --
+                </option>
+
                 <option th:each="c : ${children}"
                         th:value="${c.id}"
                         th:text="${c.name + ' (' + c.nickname + ')'}">
                 </option>
             </select>
+
+            <a href="/member/child" class="text-sm text-blue-600 px-4 hover:underline">+ 자녀 추가하기</a>
+
         </div>
 
         <div id="childInfo" class="mb-6 p-4 border rounded bg-gray-50 hidden">
@@ -136,7 +154,7 @@
               historyData = data;
               answerList.innerHTML = '';
               if (data.length === 0) {
-                answerList.innerHTML = `<p class="text-gray-500">답변 이력이 없습니다.</p>`;
+                answerList.innerHTML = `<p class="text-gray-500 text-center italic">답변 이력이 없습니다.</p>`;
                 return;
               }
               const byDate = {};

--- a/src/main/resources/templates/surveySetRequest.html
+++ b/src/main/resources/templates/surveySetRequest.html
@@ -132,7 +132,6 @@
             return r.json();
           })
           .then(res => {
-              alert('저장 완료');
               const typeLabel = document.querySelector("#typeLabel").textContent.trim();
               const payload = encodeURIComponent(JSON.stringify(res));
               if(typeLabel === '그룹 문진') {


### PR DESCRIPTION
### 담당자 그룹 문진 관리 페이지에 대하여 기능 추가
- 로그인한 담당자의 타겟그룹에 대한 문진만 출력
- 문진 생성 시, 로그인한 담당자의 타겟그룹으로 자동 저장 추가
- 문진 수정 시에도 타겟그룹은 유지되도록 설정
- 리스트 페이지에서 필터링 결과가 없을 경우 없다는 문구 출력

### 자녀 없는 회원이 데일리 문진페이지 진입 시,
### 셀렉트 박스의 --자녀를 선택하세요-- 문구가
### "등록된 자녀가 없습니다."로 보여짐
### 데일리 문진에 자녀 추가 링크 추가
- 위와 같은 작업 데일리, 기록, 그룹, 특별 문진 이력 페이지에도 추가

### 커뮤니티 기능 추가 구현
- 육아정보 커뮤니티에 댓글 수정 및 삭제 기능 구현
- 정책정보 커뮤니티에 댓글 수정 및 삭제 기능 구현
- 공지사항 커뮤니티에 댓글 수정 및 삭제 기능 구현
- 전체글 커뮤니티에 댓글 수정 및 삭제 기능 구현

### 1:1문의 관리자 페이지 기능 추가
- 상태(답변 대기, 답변 완료) 필터링 추가
- 제목 검색 기능 추가

### 담당자 헤더에 담당자 홈페이지 URL 수정
### 문진 세트 작성 후 제출 시 "저장완료" alert 제거