### PR TITLE
**담당자 알림 발송 기능 개선**

### DIFF
--- a/src/main/java/com/example/demo/fcm/controller/ManagerNotificationController.java
+++ b/src/main/java/com/example/demo/fcm/controller/ManagerNotificationController.java
@@ -2,6 +2,7 @@ package com.example.demo.fcm.controller;
 
 
 import com.example.demo.dto.UserDTO;
+import com.example.demo.fcm.dto.AdminFcmSendResultDto;
 import com.example.demo.fcm.dto.FcmSendResultDto;
 import com.example.demo.fcm.service.FcmService;
 import com.example.demo.survey.entity.SurveySet;
@@ -56,7 +57,7 @@ public class ManagerNotificationController {
 
         try {
             // 서비스로부터 발송 결과(DTO)를 받습니다.
-            FcmSendResultDto result = fcmService.sendSurveySetToGroupMembers(managerId, setId);
+            AdminFcmSendResultDto result = fcmService.sendSurveySetToGroupMembers(managerId, setId);
             model.addAttribute("sendResult", result);
             model.addAttribute("message", "✅ 문진 알림이 정상적으로 요청되었습니다. 아래에서 발송 결과를 확인하세요.");
         } catch (Exception e) {

--- a/src/main/java/com/example/demo/fcm/service/FcmService.java
+++ b/src/main/java/com/example/demo/fcm/service/FcmService.java
@@ -5,7 +5,6 @@ import com.example.demo.enums.FcmCategory;
 import com.example.demo.enums.SurveyCategory;
 import com.example.demo.enums.TargetGroup;
 import com.example.demo.fcm.dto.AdminFcmSendResultDto;
-import com.example.demo.fcm.dto.FcmSendResultDto;
 import com.example.demo.fcm.dto.NoticeDto;
 import com.example.demo.fcm.dto.RecipientResultDto;
 import com.example.demo.fcm.entity.FcmSendHistory;
@@ -25,7 +24,6 @@ import com.example.demo.users.repository.ManagerRepository;
 import com.example.demo.users.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -44,8 +42,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class FcmService {
-//    @Value("${app.domain}")
-    private String appDomain;
+
 
     private final UserRepository userRepository;
     private final UserFcmTokenRepository tokenRepository;
@@ -60,51 +57,27 @@ public class FcmService {
      * 관리자 알림 발송 메인 서비스 메소드
      * - 컨트롤러로부터 모든 요청 파라미터를 받아 로직을 오케스트레이션합니다.
      */
-    public AdminFcmSendResultDto sendAdvancedNotification(Admin sender, String targetType, AgeGroup ageGroup, TargetGroup targetGroup, FcmCategory fcmCategory, SurveyCategory surveyCategory, Long setId, String customTitle, String customBody) {
+    public AdminFcmSendResultDto sendAdvancedNotification(Admin sender, String targetType, AgeGroup ageGroupFromFilter, TargetGroup targetGroup, FcmCategory fcmCategory, SurveyCategory surveyCategory, Long setId, String customTitle, String customBody) {
 
-        Map<Users, List<Child>> targetUserMap = findTargetParentAndChildMap(targetType, ageGroup, targetGroup, surveyCategory);
+        SurveySet set = null;
+        if (setId != null) {
+            set = surveySetService.getById(setId);
+        }
+
+        AgeGroup finalAgeGroup = (set != null) ? set.getAgeGroup() : ageGroupFromFilter;
+
+        Map<Users, List<Child>> targetUserMap = findTargetParentAndChildMap(targetType, finalAgeGroup, targetGroup, surveyCategory);
+
         if (targetUserMap.isEmpty()) {
             return AdminFcmSendResultDto.createEmptyResult(targetType);
         }
 
         String targetCondition = String.format("target=%s, ageGroup=%s, targetGroup=%s, surveyCategory=%s, setId=%s",
-                targetType, ageGroup, targetGroup, surveyCategory, (setId != null ? setId.toString() : "null"));
+                targetType, finalAgeGroup, targetGroup, surveyCategory, (setId != null ? setId.toString() : "null"));
 
-        return sendBulkNotificationAndSaveHistory(sender, targetUserMap, setId, customTitle, customBody, fcmCategory, targetCondition, targetType);
+        return sendBulkNotificationAndSaveHistory(sender, targetUserMap, set, customTitle, customBody, fcmCategory, targetCondition, targetType);
     }
 
-    /**
-     *  대상자 조회 로직 분리
-     * - 각 조건에 맞는 사용자 목록을 DB에서 직접 조회
-     */
-    private List<Users> findTargetUsers(String targetType, AgeGroup ageGroup, TargetGroup targetGroup, SurveyCategory surveyCategory) { // 파라미터명을 category -> surveyCategory로 명확화
-
-        // "SPECIAL_RISK" 대상: 위험군 사용자 조회
-        if ("SPECIAL_RISK".equals(targetType)) {
-            return userRepository.findUsersByChildRiskCategory(surveyCategory);
-        }
-        // "GROUP" 대상: 기관 그룹별 사용자 조회
-        else if ("GROUP".equals(targetType) && targetGroup != null) {
-            return userRepository.findUsersByChildrenInTargetGroup(targetGroup);
-        }
-        // "ALL" 대상: 전체 또는 연령대별 사용자 조회
-        else if ("ALL".equals(targetType)) {
-            // 1. 먼저 삭제되지 않은 모든 사용자를 DB에서 조회합니다.
-            List<Users> allUsers = userRepository.findAllByDeletedFalse();
-
-            // 2. 만약 ageGroup 필터가 있다면, 자바 코드로 2차 필터링을 수행합니다.
-            if (ageGroup != null) {
-                return allUsers.stream()
-                        .filter(user -> user.getMember() != null &&
-                                user.getMember().getChildren().stream()
-                                        .anyMatch(child -> child.getAgeGroup() == ageGroup))
-                        .collect(Collectors.toList());
-            }
-            return allUsers;
-        }
-
-        return new ArrayList<>();
-    }
     /**
      *  대상자 조회 로직: 이제 학부모와 해당 자녀를 Map으로 묶어서 반환합니다.
      */
@@ -148,64 +121,59 @@ public class FcmService {
                 .collect(Collectors.groupingBy(child -> child.getParent().getUsers()));
     }
 
-
     /**
-     *  발송 및 저장 로직 통합
+     * 발송 및 저장 로직 통합: 자녀별 개별 알림 발송
      */
-    private AdminFcmSendResultDto sendBulkNotificationAndSaveHistory(Admin sender, Map<Users, List<Child>> targetUserMap, Long setId, String customTitle, String customBody, FcmCategory fcmCategory, String targetCondition, String targetType) {
+    private AdminFcmSendResultDto sendBulkNotificationAndSaveHistory(Admin sender, Map<Users, List<Child>> targetUserMap, SurveySet set, String customTitle, String customBody, FcmCategory fcmCategory, String targetCondition, String targetType) {
         List<RecipientResultDto> successfulRecipients = new ArrayList<>();
         List<RecipientResultDto> failedRecipients = new ArrayList<>();
         List<Notice> noticesToSave = new ArrayList<>();
+        // [변경] 전체 대상자 수를 부모(user)가 아닌 자녀(child) 기준으로 세기 위해 변수 추가
+        int totalChildCount = 0;
 
-        SurveySet set = (setId != null) ? surveySetService.getById(setId) : null;
+//        SurveySet set = (setId != null) ? surveySetService.getById(setId) : null;
 
         for (Map.Entry<Users, List<Child>> entry : targetUserMap.entrySet()) {
             Users user = entry.getKey();
             List<Child> children = entry.getValue();
 
-            String personalizedTitle, personalizedBody, personalizedUrl = null;
+            totalChildCount += children.size();
 
-            if (set != null && !children.isEmpty()) {
-                String childrenNames = children.stream().map(Child::getName).collect(Collectors.joining(", "));
-                personalizedTitle = String.format("[문진 요청] %s 어린이를 위한 새 문진이 도착했어요!", childrenNames);
-                personalizedBody = String.format("'%s' 문진을 확인하고 답변을 부탁드립니다.", set.getSetTitle());
-                personalizedUrl = appDomain + "/surveySet/request/" + setId + "?childId=" + children.get(0).getId();
-            } else {
-                personalizedTitle = customTitle;
-                personalizedBody = customBody;
-            }
+            for (Child child : children) {
+                String personalizedTitle, personalizedBody, personalizedUrl = null;
 
-            noticesToSave.add(Notice.builder().user(user).title(personalizedTitle).body(personalizedBody).category(fcmCategory).url(personalizedUrl).sentAt(LocalDateTime.now()).build());
-            boolean sent = sendFcmOnly(user, personalizedTitle, personalizedBody, personalizedUrl);
-            if (sent) {
-                List<String> childNames = children.stream().map(Child::getName).collect(Collectors.toList());
-                successfulRecipients.add(new RecipientResultDto(user.getName(), childNames));
-            } else {
-                List<String> childNames = children.stream().map(Child::getName).collect(Collectors.toList());
-                failedRecipients.add(new RecipientResultDto(user.getName(), childNames));
+                if (set != null) {
+                    personalizedTitle = String.format("[문진 요청] %s 어린이를 위한 새 문진이 도착했어요!", child.getName());
+                    personalizedBody = String.format("'%s' 문진을 확인하고 답변을 부탁드립니다.", set.getSetTitle());
+                    personalizedUrl = "/surveySet/request/" + set.getSetId() + "?childId=" + child.getId();
+                } else {
+                    personalizedTitle = customTitle;
+                    personalizedBody = customBody;
+                }
+
+                //  한 명의 자녀에 대한 알림 1개를 생성하고 발송합니다.
+                noticesToSave.add(Notice.builder().user(user).title(personalizedTitle).body(personalizedBody).category(fcmCategory).url(personalizedUrl).sentAt(LocalDateTime.now()).build());
+                boolean sent = sendFcmOnly(user, personalizedTitle, personalizedBody, personalizedUrl);
+
+                if (sent) {
+                    successfulRecipients.add(new RecipientResultDto(user.getName(), List.of(child.getName())));
+                } else {
+                    failedRecipients.add(new RecipientResultDto(user.getName(), List.of(child.getName())));
+                }
             }
         }
 
         noticeRepository.saveAll(noticesToSave);
 
-        String historyTitle;
+        String historyTitle = (set != null) ? set.getSetTitle() : customTitle;
         String historyBody = String.format("관리자(%s)가 발송한 알림", sender.getName());
-        String historyLink = null;
-
-        if (set != null) {
-            historyTitle = set.getSetTitle();
-            historyLink = appDomain + "/admin/surveySet/" + setId;
-        } else {
-            historyTitle = customTitle;
-        }
+        String historyLink = (set != null) ? "/admin/surveySet/" + set.getSetId() : null;
 
         historyRepository.save(FcmSendHistory.builder()
                 .adminSender(sender)
-                .title(historyTitle)
-                .body(historyBody)
-                .category(fcmCategory)
+                .title(historyTitle).body(historyBody).category(fcmCategory)
                 .targetCondition(targetCondition)
-                .targetCount(targetUserMap.size())
+                .targetCount(totalChildCount)
                 .successCount(successfulRecipients.size())
                 .sentAt(LocalDateTime.now())
                 .link(historyLink)
@@ -213,7 +181,7 @@ public class FcmService {
 
         return AdminFcmSendResultDto.builder()
                 .targetType(targetType)
-                .totalTargetCount(targetUserMap.size())
+                .totalTargetCount(totalChildCount)
                 .successCount(successfulRecipients.size())
                 .successfulRecipients(successfulRecipients)
                 .failedRecipients(failedRecipients)
@@ -338,19 +306,26 @@ public class FcmService {
     /**
      * 담당자용 문진 세트 발송
      */
-    public FcmSendResultDto sendSurveySetToGroupMembers(Long managerId, Long setId) {
+    public AdminFcmSendResultDto sendSurveySetToGroupMembers(Long managerId, Long setId) {
         Manager manager = managerRepository.findById(managerId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 매니저입니다. ID: " + managerId));
         SurveySet set = surveySetService.getById(setId);
-        List<Child> targetChildren = childRepository.findByGroupId(manager.getGroup().getId());
+
+        List<Child> childrenInGroup = childRepository.findByGroupId(manager.getGroup().getId());
+
+        AgeGroup surveySetAgeGroup = set.getAgeGroup();
+        List<Child> targetChildren = childrenInGroup.stream()
+                .filter(child -> child.getAgeGroup() == surveySetAgeGroup)
+                .collect(Collectors.toList());
 
         if (targetChildren.isEmpty()) {
-            log.info("그룹 ID {} 에 해당하는 자녀가 없어 알림을 발송하지 않습니다.", manager.getGroup().getId());
-            return new FcmSendResultDto(0, 0, new ArrayList<>(), new ArrayList<>());
+            log.info("그룹 ID {} 에는 해당 문진 세트({})의 연령대에 맞는 자녀가 없어 알림을 발송하지 않습니다.",
+                    manager.getGroup().getId(), set.getSetTitle());
+            return AdminFcmSendResultDto.createEmptyResult("GROUP");
         }
 
-        List<String> successfulNames = new ArrayList<>();
-        List<String> failedNames = new ArrayList<>();
+        List<RecipientResultDto> successfulRecipients = new ArrayList<>();
+        List<RecipientResultDto> failedRecipients = new ArrayList<>();
         List<Notice> noticesToSave = new ArrayList<>();
         Users sender = manager.getUsers();
 
@@ -362,13 +337,13 @@ public class FcmService {
         for (Child child : targetChildren) {
             Users parent = child.getParent().getUsers();
             if (parent == null || parent.isDeleted()) {
-                failedNames.add(child.getName() + " (학부모 정보 없음)");
+                failedRecipients.add(new RecipientResultDto("정보 없음", List.of(child.getName() + " (학부모 정보 없음)")));
                 continue;
             }
 
             String title = String.format("[문진 요청] %s 어린이를 위한 새 문진이 도착했어요!", child.getName());
             String body = String.format("'%s' 문진을 확인하고 답변을 부탁드립니다.", set.getSetTitle());
-            String link = "http://localhost:8080/surveySet/request/" + setId + "?childId=" + child.getId();
+            String link = "/surveySet/request/" + setId + "?childId=" + child.getId();
 
             noticesToSave.add(Notice.builder().user(parent).title(title).body(body)
                     .category(FcmCategory.GROUP).url(link).sentAt(LocalDateTime.now()).build());
@@ -376,9 +351,9 @@ public class FcmService {
             boolean sent = sendFcmOnly(parent, title, body, link);
 
             if (sent) {
-                successfulNames.add(child.getName());
+                successfulRecipients.add(new RecipientResultDto(parent.getName(), List.of(child.getName())));
             } else {
-                failedNames.add(child.getName() + " (발송 실패)");
+                failedRecipients.add(new RecipientResultDto(parent.getName(), List.of(child.getName() + " (발송 실패)")));
             }
         }
 
@@ -388,17 +363,23 @@ public class FcmService {
                 FcmSendHistory.builder()
                         .sender(sender)
                         .title(set.getSetTitle())
-                        .body(String.format("%s 담당자가 그룹 문진을 발송했습니다.", sender.getName()))
+                        .body(String.format("담당자(%s)가 발송한 알림.", sender.getName()))
                         .category(FcmCategory.GROUP)
                         .targetCondition(targetCondition)
-                        .link("/surveySet/request/" + setId)
+                        .link("/admin/surveySet/" + setId)
                         .targetCount(targetChildren.size())
-                        .successCount(successfulNames.size())
+                        .successCount(successfulRecipients.size())
                         .sentAt(LocalDateTime.now())
                         .build()
         );
 
-        return new FcmSendResultDto(targetChildren.size(), successfulNames.size(), successfulNames, failedNames);
+        return AdminFcmSendResultDto.builder()
+                .targetType("GROUP")
+                .totalTargetCount(targetChildren.size())
+                .successCount(successfulRecipients.size())
+                .successfulRecipients(successfulRecipients)
+                .failedRecipients(failedRecipients)
+                .build();
     }
 
     // 특정 유저가 받은 알림을 최신 순으로 10개만 조회

--- a/src/main/resources/templates/admin/notification/notificationView.html
+++ b/src/main/resources/templates/admin/notification/notificationView.html
@@ -76,17 +76,6 @@
                                 <input type="hidden" class="history-data" th:value="${history.body}">
                                 <p class="text-gray-900 whitespace-no-wrap" th:text="${#temporals.format(history.sentAt, 'yyyy-MM-dd HH:mm')}"></p>
                             </td>
-<!--                            <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">-->
-<!--                                <th:block th:if="${history.sender == null}">-->
-<!--                                    <span class="relative inline-block px-3 py-1 font-semibold text-green-900 leading-tight">-->
-<!--                                        <span aria-hidden class="absolute inset-0 bg-green-200 opacity-50 rounded-full"></span>-->
-<!--                                        <span class="relative">시스템</span>-->
-<!--                                    </span>-->
-<!--                                </th:block>-->
-<!--                                <th:block th:unless="${history.sender == null}">-->
-<!--                                    <p class="text-gray-900 whitespace-no-wrap" th:text="${history.sender.name}"></p>-->
-<!--                                </th:block>-->
-<!--                            </td>-->
                             <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
                                 <span th:text="${history.senderName}" class="text-gray-800"></span>
                             </td>

--- a/src/main/resources/templates/fragments/managerHeader.html
+++ b/src/main/resources/templates/fragments/managerHeader.html
@@ -52,6 +52,9 @@
                     <li class="relative group">
                         <a href="/manager/surveys/group" class="block px-1 py-4 text-md hover:text-[#FEF9F3] whitespace-nowrap">문진 관리</a>
                     </li>
+                    <li class="relative group">
+                        <a href="/manager/notification/form" class="block px-1 py-4 text-md hover:text-[#FEF9F3] whitespace-nowrap">알림 발송</a>
+                    </li>
 
                     <li class="relative group">
                         <a href="/qnaList" class="block px-1 py-4 text-md hover:text-[#FEF9F3] whitespace-nowrap">문의 내역</a>

--- a/src/main/resources/templates/manager/notification/notificationForm.html
+++ b/src/main/resources/templates/manager/notification/notificationForm.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{layout/default_layout}">
+      layout:decorate="~{layout/managerLayout}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -63,10 +63,10 @@
 
             <div class="p-4 border rounded bg-gray-50 mb-4 grid grid-cols-1 md:grid-cols-2 gap-4">
                 <p class="font-semibold text-gray-800">✅ 성공: <span class="text-green-600 font-bold" th:text="${sendResult.successCount}">0</span> 명</p>
-                <p class="font-semibold text-gray-800">❌ 실패: <span class="text-red-600 font-bold" th:text="${sendResult.failedRecipientNames.size()}">0</span> 명</p>
+                <p class="font-semibold text-gray-800">❌ 실패: <span class="text-red-600 font-bold" th:text="${sendResult.failedRecipients.size()}">0</span> 명</p>
             </div>
 
-            <div th:if="${!#lists.isEmpty(sendResult.successfulRecipientNames)}" id="success-accordion" class="border rounded mb-3">
+            <div th:if="${sendResult != null && !#lists.isEmpty(sendResult.successfulRecipients)}" id="success-accordion" class="border rounded mb-3">
                 <div class="accordion-header cursor-pointer bg-gray-100 p-3 flex justify-between items-center hover:bg-gray-200 transition">
                     <span class="font-semibold text-gray-700">성공 내역 확인하기</span>
                     <i class="chevron-icon fa-solid fa-chevron-down"></i>
@@ -75,12 +75,14 @@
                     <ul class="data-list list-disc pl-5 space-y-2 text-gray-600"></ul>
                     <div class="pagination-controls mt-4 flex justify-center items-center space-x-2 text-sm"></div>
                     <div class="hidden-data" style="display:none;">
-                        <span th:each="name : ${sendResult.successfulRecipientNames}" th:text="${name}"></span>
+<!--                        <span th:each="name : ${sendResult.successfulRecipientNames}" th:text="${name}"></span>-->
+                        <span th:each="res : ${sendResult.successfulRecipients}"
+                              th:text="${res.parentName + ' 님 [자녀: ' + #strings.listJoin(res.childNames, ', ') + ']'}"></span>
                     </div>
                 </div>
             </div>
 
-            <div th:if="${!#lists.isEmpty(sendResult.failedRecipientNames)}" id="failure-accordion" class="border rounded border-red-200">
+            <div th:if="${sendResult != null && !#lists.isEmpty(sendResult.failedRecipients)}" id="failure-accordion" class="border rounded border-red-200">
                 <div class="accordion-header cursor-pointer bg-red-50 p-3 flex justify-between items-center hover:bg-red-100 transition">
                     <span class="font-semibold text-red-700">실패 내역 확인하기</span>
                     <i class="chevron-icon fa-solid fa-chevron-down text-red-700"></i>
@@ -89,7 +91,9 @@
                     <ul class="data-list list-disc pl-5 space-y-2 text-red-600"></ul>
                     <div class="pagination-controls mt-4 flex justify-center items-center space-x-2 text-sm"></div>
                     <div class="hidden-data" style="display:none;">
-                        <span th:each="name : ${sendResult.failedRecipientNames}" th:text="${name}"></span>
+<!--                        <span th:each="name : ${sendResult.failedRecipientNames}" th:text="${name}"></span>-->
+                        <span th:each="res : ${sendResult.failedRecipients}"
+                              th:text="${res.parentName + ' 님 [자녀: ' + #strings.listJoin(res.childNames, ', ') + ']'}"></span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**담당자 알림 발송 기능 개선**
    -   **문진 세트 연령대 필터링 추가**: 담당자가 문진 세트 발송 시, 세트의 대상 연령과 자녀의 실제 연령이 일치하는 경우에만 알림이 가도록 필터링 로직을 추가했습니다.
    -   **발송 결과 DTO 통일**: 관리자 기능과 일관성을 맞추기 위해, 발송 결과에 부모와 자녀 이름이 함께 표시되도록 `RecipientResultDto`를 재사용하고 관련 로직을 수정했습니다.