### PR TITLE
0704박지수

### DIFF
--- a/src/main/java/com/example/demo/community/controller/ParentingBoardAdminController.java
+++ b/src/main/java/com/example/demo/community/controller/ParentingBoardAdminController.java
@@ -74,6 +74,7 @@ public class ParentingBoardAdminController {
                 .collect(Collectors.toList());
         model.addAttribute("commentList", commentsPage.getContent());
         model.addAttribute("commentNicknames", commentNicknames);
+        model.addAttribute("commentPageData",  commentsPage);
 
         return "admin/community/parentingDetail";
     }

--- a/src/main/java/com/example/demo/community/controller/PolicyBoardAdminController.java
+++ b/src/main/java/com/example/demo/community/controller/PolicyBoardAdminController.java
@@ -1,0 +1,150 @@
+package com.example.demo.community.controller;
+
+import com.example.demo.community.entity.Comment;
+import com.example.demo.community.entity.CommunityBoard;
+import com.example.demo.community.service.CommentService;
+import com.example.demo.community.service.CommunityBoardService;
+import com.example.demo.enums.AgeGroup;
+import com.example.demo.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("/admin/community/policy")
+@RequiredArgsConstructor
+public class PolicyBoardAdminController {
+
+    private final CommunityBoardService boardService;
+    private final CommentService    commentService;
+    private final UserService       userService;
+
+    // 정책정보 전용 하위카테고리
+    private final List<String> subCategories = Arrays.asList(
+            "보육지원", "출산지원", "건강검진", "양육휴가", "재정지원"
+    );
+    // 연령대 필터 (ALL, VARIOUS 제외)
+    private final List<AgeGroup> ageGroups = Arrays.stream(AgeGroup.values())
+            .filter(a -> a != AgeGroup.ALL && a != AgeGroup.VARIOUS)
+            .collect(Collectors.toList());
+
+    /** 1) 목록 (필터/검색/정렬/페이징) */
+    @GetMapping("/list")
+    public String list(
+            Model model,
+            @RequestParam(defaultValue = "전체") String subCategory,
+            @RequestParam(defaultValue = "ALL") AgeGroup ageGroup,
+            @RequestParam(defaultValue = "") String keyword,
+            @RequestParam(defaultValue = "popular") String sort,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        Page<CommunityBoard> boards = boardService.getList(
+                "policyInformation",
+                subCategory, ageGroup, keyword, sort, page
+        );
+
+        model.addAttribute("boards",       boards.getContent());
+        model.addAttribute("pageData",     boards);
+        model.addAttribute("subCategory",  subCategory);
+        model.addAttribute("ageGroup",     ageGroup);
+        model.addAttribute("keyword",      keyword);
+        model.addAttribute("sort",         sort);
+        model.addAttribute("subCategories", subCategories);
+        model.addAttribute("ageGroups",     ageGroups);
+
+        return "admin/community/policyList";
+    }
+
+    /** 2) 상세 (조회수↑, 수정/삭제/댓글 가능) */
+    @GetMapping("/{id}")
+    public String detail(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int commentPage,
+            Model model
+    ) {
+        // 조회수 업데이트
+        CommunityBoard board = boardService.findById(id);
+        board.setViews(board.getViews() + 1);
+        boardService.save(board);
+
+        // 글 정보
+        model.addAttribute("board", board);
+        model.addAttribute("authorNickname",
+                userService.findNicknameOrDefault(board.getUsersId()));
+
+        // 댓글 페이징 & 닉네임
+        Page<Comment> commentsPage = commentService.getCommentsPage(id, commentPage);
+        List<String> commentNicknames = commentsPage.getContent().stream()
+                .map(c -> userService.findNicknameOrDefault(c.getUsersId()))
+                .toList();
+
+        model.addAttribute("commentList",      commentsPage.getContent());
+        model.addAttribute("commentNicknames", commentNicknames);
+        model.addAttribute("commentPageData",  commentsPage);
+
+        return "admin/community/policyDetail";
+    }
+
+    /** 3) 글 수정 폼 */
+    @GetMapping("/{id}/edit")
+    public String editForm(
+            @PathVariable Long id,
+            Model model
+    ) {
+        model.addAttribute("board",         boardService.findById(id));
+        model.addAttribute("subCategories", subCategories);
+        model.addAttribute("ageGroups",     ageGroups);
+        return "admin/community/policyForm";
+    }
+
+    /** 4) 글 수정 처리 */
+    @PostMapping("/{id}")
+    public String update(
+            @PathVariable Long id,
+            @ModelAttribute CommunityBoard board
+    ) {
+        CommunityBoard old = boardService.findById(id);
+        old.setCategory2(board.getCategory2());
+        old.setAgeGroup(board.getAgeGroup());
+        old.setTitle(board.getTitle());
+        old.setContent(board.getContent());
+        boardService.save(old);
+        return "redirect:/admin/community/policy/" + id;
+    }
+
+    /** 5) 글 삭제 */
+    @PostMapping("/{id}/delete")
+    public String delete(@PathVariable Long id) {
+        boardService.delete(id);
+        return "redirect:/admin/community/policy/list";
+    }
+
+    /** 6) 댓글 수정 처리 */
+    @PostMapping("/{boardId}/comments/{commentId}")
+    public String updateComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            @RequestParam String content
+    ) {
+        Comment c = commentService.findById(commentId);
+        c.setContent(content);
+        commentService.save(c);
+        return "redirect:/admin/community/policy/" + boardId;
+    }
+
+    /** 7) 댓글 삭제 */
+    @PostMapping("/{boardId}/comments/{commentId}/delete")
+    public String deleteComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId
+    ) {
+        commentService.delete(commentId);
+        return "redirect:/admin/community/policy/" + boardId;
+    }
+}

--- a/src/main/java/com/example/demo/survey/controller/GroupSurveyAdminController.java
+++ b/src/main/java/com/example/demo/survey/controller/GroupSurveyAdminController.java
@@ -2,6 +2,7 @@ package com.example.demo.survey.controller;
 
 import com.example.demo.enums.AgeGroup;
 import com.example.demo.enums.SurveyCategory;
+import com.example.demo.enums.TargetGroup;
 import com.example.demo.survey.entity.DailySurvey;
 import com.example.demo.survey.entity.GroupAnswer;
 import com.example.demo.survey.entity.GroupSurvey;
@@ -32,6 +33,11 @@ public class GroupSurveyAdminController {
     private final List<SurveyCategory> allCategories = Arrays.stream(SurveyCategory.values())
             .filter(sc -> sc != SurveyCategory.ALL && sc != SurveyCategory.VARIOUS)
             .collect(Collectors.toList());
+
+    private final List<TargetGroup> targetGroups = Arrays.stream(TargetGroup.values())
+            .filter(sc -> sc != TargetGroup.ALL)
+            .collect(Collectors.toList());
+
     private final GroupAnswerService groupAnswerService;
 
     // 1. 설문 리스트 (연령대, 카테고리 필터링)
@@ -39,31 +45,36 @@ public class GroupSurveyAdminController {
     public String list(
             @RequestParam(defaultValue = "ALL") AgeGroup ageGroup,
             @RequestParam(defaultValue = "ALL") SurveyCategory category,
+            @RequestParam(defaultValue = "ALL") TargetGroup targetGroup,
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
             Model model
     ) {
         // service 쪽에서 distinct 카테고리를 enum 리스트로 반환하도록 수정했다면
         List<SurveyCategory> categories = groupSurveyService.getDistinctCategories();
 
-        Page<GroupSurvey> surveys;
-        if (ageGroup == AgeGroup.ALL && category == SurveyCategory.ALL) {
-            // 전체
-            surveys = groupSurveyService.findAllSurveys(pageable);
-        } else if (ageGroup != AgeGroup.ALL && category == SurveyCategory.ALL) {
-            // 연령대만 필터
-            surveys = groupSurveyService.getSurveysByAgeGroup(ageGroup, pageable);
-        } else if (ageGroup == AgeGroup.ALL && category != SurveyCategory.ALL) {
-            // 카테고리만 필터
-            surveys = groupSurveyService.getSurveysByCategory(category, pageable);
-        } else {
-            // 둘 다 필터
-            surveys = groupSurveyService.getSurveysByAgeAndCategory(ageGroup, category, pageable);
+        Page<GroupSurvey> surveys = groupSurveyService.findByFilters(
+                ageGroup, category, targetGroup, pageable);
+
+        int total = surveys.getTotalPages();
+        int curr  = surveys.getNumber();
+        int window = 10;
+
+        int startPage = Math.max(0, curr - window/2);
+        int endPage   = Math.min(total-1, startPage + window - 1);
+        if (endPage - startPage < window -1) {
+            startPage = Math.max(0, endPage - window + 1);
         }
+
+        model.addAttribute("surveys",   surveys);
+        model.addAttribute("startPage", startPage);
+        model.addAttribute("endPage",   endPage);
 
         model.addAttribute("ageGroup", ageGroup);
         model.addAttribute("category", category);
+        model.addAttribute("targetGroup",  targetGroup);
         model.addAttribute("ageGroups", ageGroups);
         model.addAttribute("categories", categories);
+        model.addAttribute("targetGroups", targetGroups);
         model.addAttribute("surveys", surveys);
         return "admin/surveys/groupList";
     }
@@ -74,6 +85,7 @@ public class GroupSurveyAdminController {
         model.addAttribute("survey", new GroupSurvey());
         model.addAttribute("ageGroups", ageGroups);
         model.addAttribute("categories", allCategories);
+        model.addAttribute("targetGroups", targetGroups);
         return "admin/surveys/groupForm";
     }
 
@@ -91,6 +103,7 @@ public class GroupSurveyAdminController {
         model.addAttribute("survey", survey);
         model.addAttribute("ageGroups", ageGroups);
         model.addAttribute("categories", allCategories);
+        model.addAttribute("targetGroups", targetGroups);
         return "admin/surveys/groupForm";
     }
 
@@ -98,12 +111,13 @@ public class GroupSurveyAdminController {
     @PostMapping("/{id}")
     public String update(
             @PathVariable Long id,
-            @ModelAttribute DailySurvey formData
+            @ModelAttribute GroupSurvey formData
     ) {
         GroupSurvey survey = groupSurveyService.findById(id);
         // formData.getAgeGroup() 은 이제 AgeGroup enum
         survey.setAgeGroup(formData.getAgeGroup());
         survey.setCategory(formData.getCategory());
+        survey.setTargetGroup(formData.getRawTargetGroup());
         survey.setQuestion(formData.getQuestion());
         survey.setAnswer1(formData.getAnswer1());
         survey.setAnswer2(formData.getAnswer2());

--- a/src/main/java/com/example/demo/survey/controller/SurveySetController.java
+++ b/src/main/java/com/example/demo/survey/controller/SurveySetController.java
@@ -38,6 +38,11 @@ public class SurveySetController {
             .filter(sc -> sc != SurveyCategory.ALL && sc != SurveyCategory.VARIOUS)
             .collect(Collectors.toList());
 
+    // TargetGroup 필터 옵션 (ALL 제외)
+    private final List<TargetGroup> targetOptions = Arrays.stream(TargetGroup.values())
+            .filter(t -> t != TargetGroup.ALL)
+            .collect(Collectors.toList());
+
     // 관리자 리스트 + 필터
     @GetMapping
     public String list(
@@ -49,6 +54,7 @@ public class SurveySetController {
         model.addAttribute("page", page);
         model.addAttribute("ageOptions", ageOptions);
         model.addAttribute("categoryOptions", categoryOptions);
+        model.addAttribute("targetOptions",    targetOptions);
         return "admin/surveys/setList";
     }
 

--- a/src/main/java/com/example/demo/survey/entity/GroupSurvey.java
+++ b/src/main/java/com/example/demo/survey/entity/GroupSurvey.java
@@ -78,4 +78,8 @@ public class GroupSurvey extends BaseEntity implements BaseSurvey {
     public Optional<TargetGroup> getTargetGroup() {
         return Optional.of(targetGroup);
     }
+
+    public TargetGroup getRawTargetGroup() {
+        return this.targetGroup;
+    }
 }

--- a/src/main/java/com/example/demo/survey/repository/GroupSurveyRepository.java
+++ b/src/main/java/com/example/demo/survey/repository/GroupSurveyRepository.java
@@ -34,6 +34,8 @@ public interface GroupSurveyRepository extends JpaRepository<GroupSurvey, Long> 
 
     List<GroupSurvey> findByCategoryAndDeletedFalse(SurveyCategory sc);
 
+    Page<GroupSurvey> findByCategoryAndDeletedFalse(SurveyCategory sc, Pageable pageable);
+
 
     @Query("select gs from GroupSurvey gs where gs.targetGroup like concat(:groupPrefix, '%') and gs.deleted = false")
     List<GroupSurvey> findByTargetGroupPrefix(@Param("groupPrefix") String groupPrefix);

--- a/src/main/java/com/example/demo/survey/service/GroupSurveyService.java
+++ b/src/main/java/com/example/demo/survey/service/GroupSurveyService.java
@@ -279,21 +279,41 @@ public class GroupSurveyService {
             TargetGroup targetGroup,
             Pageable pageable
     ) {
-        if (ageGroup == AgeGroup.ALL && category == SurveyCategory.ALL) {
-            return groupSurveyRepository
-                    .findByTargetGroupAndDeletedFalse(targetGroup, pageable);
+        boolean allAge    = ageGroup    == AgeGroup.ALL;
+        boolean allCat    = category    == SurveyCategory.ALL;
+        boolean allTarget = targetGroup == TargetGroup.ALL;
+
+        // 1) 전체(필터 전부 무시)
+        if (allAge && allCat && allTarget) {
+            return groupSurveyRepository.findAllByDeletedFalse(pageable);
         }
-        if (ageGroup != AgeGroup.ALL && category == SurveyCategory.ALL) {
-            return groupSurveyRepository
-                    .findByAgeGroupAndTargetGroupAndDeletedFalse(ageGroup, targetGroup, pageable);
+        // 2) 그룹만
+        if (allAge && allCat && !allTarget) {
+            return groupSurveyRepository.findByTargetGroupAndDeletedFalse(targetGroup, pageable);
         }
-        if (ageGroup == AgeGroup.ALL && category != SurveyCategory.ALL) {
-            return groupSurveyRepository
-                    .findByCategoryAndTargetGroupAndDeletedFalse(category, targetGroup, pageable);
+        // 3) 연령만
+        if (!allAge && allCat && allTarget) {
+            return groupSurveyRepository.findByAgeGroupAndDeletedFalse(ageGroup, pageable);
         }
-        // 둘 다 필터
-        return groupSurveyRepository
-                .findByAgeGroupAndCategoryAndTargetGroupAndDeletedFalse(
-                        ageGroup, category, targetGroup, pageable);
+        // 4) **카테고리만**  → 이 줄이 빠지면 “전체 그룹” 분기로도, “연령+카테고리” 분기로도 안 걸러집니다!
+        if (allAge && !allCat && allTarget) {
+            return groupSurveyRepository.findByCategoryAndDeletedFalse(category, pageable);
+        }
+        // 5) 연령+카테고리
+        if (!allAge && !allCat && allTarget) {
+            return groupSurveyRepository.findByAgeGroupAndCategoryAndDeletedFalse(ageGroup, category, pageable);
+        }
+        // 6) 연령+그룹
+        if (!allAge && allCat && !allTarget) {
+            return groupSurveyRepository.findByAgeGroupAndTargetGroupAndDeletedFalse(ageGroup, targetGroup, pageable);
+        }
+        // 7) 카테고리+그룹
+        if (allAge && !allCat && !allTarget) {
+            return groupSurveyRepository.findByCategoryAndTargetGroupAndDeletedFalse(category, targetGroup, pageable);
+        }
+        // 8) 연령+카테고리+그룹
+        return groupSurveyRepository.findByAgeGroupAndCategoryAndTargetGroupAndDeletedFalse(
+                ageGroup, category, targetGroup, pageable
+        );
     }
 }

--- a/src/main/resources/templates/admin/community/policyDetail.html
+++ b/src/main/resources/templates/admin/community/policyDetail.html
@@ -5,7 +5,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
-    <title>관리자 – 육아정보 게시글 상세</title>
+    <title>관리자 – 정책정보 게시글 상세</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <th:block layout:fragment="content">
@@ -25,62 +25,63 @@
 
         <!-- 게시글 관리 버튼 -->
         <div class="flex gap-4 mb-6">
-            <a th:href="@{/admin/community/parenting/{id}/edit(id=${board.communityId})}"
+            <a th:href="@{/admin/community/policy/{id}/edit(id=${board.communityId})}"
                class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">
                 수정
             </a>
-            <form th:action="@{/admin/community/parenting/{id}/delete(id=${board.communityId})}"
+            <form th:action="@{/admin/community/policy/{id}/delete(id=${board.communityId})}"
                   method="post"
                   onsubmit="return confirm('정말 삭제하시겠습니까?');">
                 <button class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">
                     삭제
                 </button>
             </form>
-                <a th:href="@{/admin/community/parenting/list}"
-                   class="bg-[#374151] text-white px-4 py-2 rounded hover:opacity-90">목록</a>
+            <a th:href="@{/admin/community/policy/list}"
+               class="bg-[#374151] text-white px-4 py-2 rounded hover:opacity-90">목록</a>
         </div>
 
         <!-- 댓글 리스트 -->
         <h3 class="text-xl font-semibold text-gray-800 mb-4">댓글</h3>
         <div class="space-y-4 mb-6">
-            <div th:each="c,stat : ${commentList}"
+            <div th:each="c, stat : ${commentList}"
                  class="bg-white p-4 rounded-lg shadow-sm hover:shadow-md transition-shadow">
                 <div class="flex items-start justify-between">
-                <div class="flex-1">
-                    <p class="text-gray-800">
-                <span class="font-semibold text-[#374151]"
-                  th:text="${commentNicknames[stat.index]}">닉네임</span>
-                        <span>·</span>
-                        <span th:text="${c.content}">댓글 내용</span>
-                    </p>
-                    <p class="text-xs text-gray-400 mt-1"
-                       th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">
-                        2025.07.03 12:34
-                    </p>
-                </div>
-                <div class="ml-4 flex-shrink-0 flex space-x-2">
-                    <!-- 수정 모달 오픈 버튼 -->
-                    <button type="button"
-                            class="text-blue-600 text-sm"
-                            th:attr="data-comment-id=${c.id},data-comment-content=${c.content}"
-                            onclick="openCommentModal(this)">
-                        수정
-                    </button>
-                    <form th:action="@{/admin/community/parenting/{boardId}/comments/{commentId}/delete(
-                            boardId=${board.communityId},
-                            commentId=${c.id})}"
-                          method="post"
-                          onsubmit="return confirm('댓글을 삭제하시겠습니까?');">
-                        <button class="text-red-600 text-sm">삭제</button>
-                    </form>
+                    <div class="flex-1">
+                        <p class="text-gray-800">
+                            <span class="font-semibold text-[#374151]"
+                                  th:text="${commentNicknames[stat.index]}">닉네임</span>
+                            <span>·</span>
+                            <span th:text="${c.content}">댓글 내용</span>
+                        </p>
+                        <p class="text-xs text-gray-400 mt-1"
+                           th:text="${#temporals.format(c.createdAt,'yyyy.MM.dd HH:mm')}">
+                            2025.07.03 12:34
+                        </p>
+                    </div>
+                    <div class="ml-4 flex-shrink-0 flex space-x-2">
+                        <!-- 수정 모달 오픈 버튼 -->
+                        <button type="button"
+                                class="text-blue-600 text-sm"
+                                th:attr="data-comment-id=${c.id},data-comment-content=${c.content}"
+                                onclick="openCommentModal(this)">
+                            수정
+                        </button>
+                        <form th:action="@{/admin/community/policy/{boardId}/comments/{commentId}/delete(
+                                boardId=${board.communityId},
+                                commentId=${c.id})}"
+                              method="post"
+                              onsubmit="return confirm('댓글을 삭제하시겠습니까?');">
+                            <button class="text-red-600 text-sm">삭제</button>
+                        </form>
+                    </div>
                 </div>
             </div>
-        </div>
             <!-- 댓글이 없을 때 -->
             <div th:if="${#lists.isEmpty(commentList)}"
                  class="text-center text-gray-500 py-6">
                 등록된 댓글이 없습니다.
             </div>
+        </div>
     </div>
 
     <!-- 페이징 네비 -->
@@ -91,11 +92,11 @@
            class="px-3 py-1 bg-gray-200 rounded hover:bg-gray-300 transition">&lt; 이전</a>
 
         <span th:each="i : ${#numbers.sequence(0, commentPageData.totalPages - 1)}">
-                <a th:href="@{/admin/community/policy/{id}(id=${board.communityId}, commentPage=${i})}"
-                   th:text="${i + 1}"
-                   th:classappend="${i == commentPageData.number} ? 'bg-[#374151] text-white' : 'bg-gray-200'"
-                   class="px-3 py-1 rounded hover:bg-[#374151] hover:text-white transition"/>
-            </span>
+                    <a th:href="@{/admin/community/policy/{id}(id=${board.communityId}, commentPage=${i})}"
+                       th:text="${i + 1}"
+                       th:classappend="${i == commentPageData.number} ? 'bg-[#374151] text-white' : 'bg-gray-200'"
+                       class="px-3 py-1 rounded hover:bg-[#374151] hover:text-white transition"/>
+                </span>
 
         <a th:if="${commentPageData.hasNext()}"
            th:href="@{/admin/community/policy/{id}(id=${board.communityId}, commentPage=${commentPageData.number+1})}"
@@ -108,9 +109,9 @@
         <div class="bg-white rounded-lg p-6 w-2/3 max-w-lg">
             <h2 class="text-xl font-semibold mb-4">댓글 수정</h2>
             <form id="commentForm" method="post" class="space-y-4">
-        <textarea id="commentContent" name="content"
-                  class="w-full border rounded px-3 py-2"
-                  rows="4"></textarea>
+                <textarea id="commentContent" name="content"
+                          class="w-full border rounded px-3 py-2"
+                          rows="4"></textarea>
                 <div class="flex justify-end space-x-2">
                     <button type="button"
                             class="px-4 py-2 border rounded hover:bg-gray-100"
@@ -128,22 +129,22 @@
 
     <script th:inline="javascript">
         /*<![CDATA[*/
-          const boardId = /*[[${board.communityId}]]*/ 0;
+        const boardId = /*[[${board.communityId}]]*/ 0;
 
-          function openCommentModal(btn) {
+        function openCommentModal(btn) {
             const commentId = btn.getAttribute('data-comment-id');
             const content   = btn.getAttribute('data-comment-content');
             const form      = document.getElementById('commentForm');
             const textarea  = document.getElementById('commentContent');
 
             textarea.value = content;
-            form.action    = `/admin/community/parenting/${boardId}/comments/${commentId}`;
+            form.action    = `/admin/community/policy/${boardId}/comments/${commentId}`;
             document.getElementById('commentModal').classList.remove('hidden');
-          }
+        }
 
-          function closeCommentModal() {
+        function closeCommentModal() {
             document.getElementById('commentModal').classList.add('hidden');
-          }
+        }
         /*]]>*/
     </script>
 

--- a/src/main/resources/templates/admin/community/policyForm.html
+++ b/src/main/resources/templates/admin/community/policyForm.html
@@ -5,13 +5,13 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
-    <title>관리자 – 육아정보 게시글 수정</title>
+    <title>관리자 – 정책정보 게시글 수정</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <th:block layout:fragment="content">
     <div class="max-w-3xl mx-auto p-6 bg-white shadow rounded-lg">
-        <h1 class="text-2xl font-bold mb-4">게시글 수정</h1>
-        <form th:action="@{/admin/community/parenting/{id}(id=${board.communityId})}"
+        <h1 class="text-2xl font-bold mb-4" th:text="${board.communityId} == null ? '게시글 작성' : '게시글 수정'">게시글 작성</h1>
+        <form th:action="@{/admin/community/policy/{id}(id=${board.communityId})}"
               th:object="${board}"
               method="post"
               class="space-y-4">
@@ -58,7 +58,9 @@
             <!-- 버튼 -->
             <div class="text-right">
                 <button type="submit"
-                        class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">저장</button>
+                        class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
+                    저장
+                </button>
             </div>
         </form>
     </div>

--- a/src/main/resources/templates/admin/community/policyList.html
+++ b/src/main/resources/templates/admin/community/policyList.html
@@ -5,17 +5,17 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
-    <title>관리자 – 육아정보 게시판</title>
+    <title>관리자 – 정책정보 게시판</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <th:block layout:fragment="content">
 
     <div class="container max-w-5xl mx-auto p-6 bg-white shadow rounded-lg">
 
-        <h2 class="text-2xl font-bold mb-4">육아정보 게시판 관리</h2>
+        <h2 class="text-2xl font-bold mb-4">정책정보 게시판 관리</h2>
 
         <!-- 필터 폼 -->
-        <form th:action="@{/admin/community/parenting/list}" method="get"
+        <form th:action="@{/admin/community/policy/list}" method="get"
               class="flex items-end gap-4 mb-6">
 
             <div class="flex flex-col">
@@ -55,7 +55,7 @@
             <div class="flex flex-col">
                 <label class="text-gray-700 font-medium mb-1">정렬</label>
                 <select name="sort"
-                        class="w-32 h-11 border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                        class="h-11 w-32 border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                     <option value="popular" th:selected="${sort == 'popular'}">인기순</option>
                     <option value="new"     th:selected="${sort == 'new'}">최신순</option>
                 </select>
@@ -80,26 +80,25 @@
                 </thead>
                 <tbody>
                 <tr th:each="b : ${boards}" class="hover:bg-gray-50">
-                    <td class="px-4 py-3" th:text="${b.category2}">수유</td>
+                    <td class="px-4 py-3" th:text="${b.category2}">카테고리</td>
                     <td class="px-4 py-3 text-[#374151] hover:underline">
-                        <a th:href="@{/admin/community/parenting/{id}(id=${b.communityId})}"
+                        <a th:href="@{/admin/community/policy/{id}(id=${b.communityId})}"
                            th:text="${b.title}">제목</a>
                     </td>
-                    <td class="px-4 py-3" th:text="${b.ageGroup.displayName}">0~1세</td>
-                    <td class="px-4 py-3" th:text="${b.views}">123</td>
+                    <td class="px-4 py-3" th:text="${b.ageGroup.displayName}">연령대</td>
+                    <td class="px-4 py-3" th:text="${b.views}">조회수</td>
                     <td class="px-4 py-3"
-                        th:text="${#temporals.format(b.createdAt,'yyyy.MM.dd')}">2025.07.03</td>
+                        th:text="${#temporals.format(b.createdAt,'yyyy.MM.dd')}">작성일</td>
                     <td class="px-4 py-3 space-x-2">
-                        <a th:href="@{/admin/community/parenting/{id}/edit(id=${b.communityId})}"
+                        <a th:href="@{/admin/community/policy/{id}/edit(id=${b.communityId})}"
                            class="text-blue-600">수정</a>
-                        <form th:action="@{/admin/community/parenting/{id}/delete(id=${b.communityId})}"
+                        <form th:action="@{/admin/community/policy/{id}/delete(id=${b.communityId})}"
                               method="post" class="inline"
                               onsubmit="return confirm('삭제하시겠습니까?');">
                             <button class="text-red-600">삭제</button>
                         </form>
                     </td>
                 </tr>
-                <!-- 데이터가 없을 때 -->
                 <tr th:if="${#lists.isEmpty(boards)}">
                     <td colspan="6" class="px-4 py-6 text-center text-gray-500">
                         검색 결과가 없습니다.
@@ -113,7 +112,7 @@
         <nav th:if="${pageData.totalElements > 0}"
              class="mt-6 flex justify-center space-x-2">
             <a th:if="${pageData.hasPrevious()}"
-               th:href="@{/admin/community/parenting/list(
+               th:href="@{/admin/community/policy/list(
                  page=${pageData.number-1},
                  subCategory=${subCategory},
                  ageGroup=${ageGroup},
@@ -122,7 +121,7 @@
                class="px-3 py-1 bg-gray-200 rounded">&lt; 이전</a>
 
             <span th:each="i : ${#numbers.sequence(0, pageData.totalPages - 1)}">
-                <a th:href="@{/admin/community/parenting/list(
+                <a th:href="@{/admin/community/policy/list(
                    page=${i},
                    subCategory=${subCategory},
                    ageGroup=${ageGroup},
@@ -134,7 +133,7 @@
             </span>
 
             <a th:if="${pageData.hasNext()}"
-               th:href="@{/admin/community/parenting/list(
+               th:href="@{/admin/community/policy/list(
                  page=${pageData.number+1},
                  subCategory=${subCategory},
                  ageGroup=${ageGroup},

--- a/src/main/resources/templates/admin/surveys/groupForm.html
+++ b/src/main/resources/templates/admin/surveys/groupForm.html
@@ -44,6 +44,24 @@
                 </select>
             </label>
 
+            <!-- 대상 그룹 -->
+            <label class="block">
+                <span class="block mb-1">대상 그룹</span>
+                <select name="targetGroup" class="border p-2 rounded w-full" required>
+                    <!-- ALL 옵션 -->
+                    <option th:value="${T(com.example.demo.enums.TargetGroup).ALL.name()}"
+                            th:text="'전체 그룹'"
+                            th:selected="${survey.rawTargetGroup == T(com.example.demo.enums.TargetGroup).ALL}">
+                    </option>
+                    <!-- 실제 enum 옵션들 -->
+                    <option th:each="tg : ${targetGroups}"
+                            th:value="${tg.name()}"
+                            th:text="${tg.displayName}"
+                            th:selected="${survey.rawTargetGroup == tg}">
+                    </option>
+                </select>
+            </label>
+
             <!-- 질문 -->
             <label class="block">
                 <span class="block mb-1">질문</span>

--- a/src/main/resources/templates/admin/surveys/groupList.html
+++ b/src/main/resources/templates/admin/surveys/groupList.html
@@ -52,6 +52,24 @@
                 </select>
             </label>
 
+            <label class="flex items-center gap-2">
+                <span>대상 그룹:</span>
+                <select name="targetGroup"
+                        class="border p-2 rounded">
+                    <!-- ALL 옵션 -->
+                    <option th:value="${T(com.example.demo.enums.TargetGroup).ALL.name()}"
+                            th:text="'전체 그룹'"
+                            th:selected="${targetGroup == T(com.example.demo.enums.TargetGroup).ALL}">
+                    </option>
+                    <!-- 실제 옵션 -->
+                    <option th:each="tg : ${targetGroups}"
+                            th:value="${tg.name()}"
+                            th:text="${tg.displayName}"
+                            th:selected="${tg == targetGroup}">
+                    </option>
+                </select>
+            </label>
+
             <button type="submit" class="bg-blue-500 text-white py-1 px-4 rounded">
                 검색
             </button>
@@ -68,6 +86,7 @@
             <tr class="bg-gray-100">
                 <th class="border p-2">연령대</th>
                 <th class="border p-2">카테고리</th>
+                <th class="border p-2">대상 그룹</th>
                 <th class="border p-2">질문</th>
                 <th class="border p-2">수정/삭제</th>
             </tr>
@@ -76,6 +95,13 @@
             <tr th:each="s : ${surveys}" class="hover:bg-gray-50">
                 <td class="border p-2" th:text="${s.ageGroup.displayName}"></td>
                 <td class="border p-2" th:text="${s.category.displayName}"></td>
+                <td class="border p-2"
+                    th:text="${
+      (!s.targetGroup.isPresent() or s.targetGroup.get() == T(com.example.demo.enums.TargetGroup).ALL)
+        ? '전체'
+        : s.targetGroup.get().displayName
+    }">
+                </td>
                 <td class="border p-2" th:text="${s.question}"></td>
                 <td class="border p-2">
                     <a th:href="@{/admin/surveys/group/{id}/edit(id=${s.id})}"
@@ -94,28 +120,33 @@
 
         <!-- 페이징 내비 -->
         <div class="mt-4 flex justify-center gap-2">
+            <!-- 이전 -->
             <a th:if="${surveys.hasPrevious()}"
                th:href="@{/admin/surveys/group(
-                     ageGroup=${ageGroup},
-                     category=${category},
-                     page=${surveys.number-1})}"
+                       ageGroup=${ageGroup},
+                       category=${category},
+                       targetGroup=${targetGroup},
+                       page=${surveys.number-1})}"
                class="px-3 py-1 bg-gray-200 rounded">이전</a>
 
-            <span th:each="i : ${#numbers.sequence(0, surveys.totalPages-1)}"
-                  class="px-2"
+            <!-- 페이지 번호 -->
+            <span th:each="i : ${#numbers.sequence(startPage,endPage)}" class="px-2"
                   th:classappend="${i == surveys.number} ? 'font-bold underline'">
-                <a th:href="@{/admin/surveys/group(
-                             ageGroup=${ageGroup},
-                             category=${category},
-                             page=${i})}"
-                   th:text="${i+1}">1</a>
+              <a th:href="@{/admin/surveys/group(
+                   ageGroup=${ageGroup},
+                   category=${category},
+                   targetGroup=${targetGroup},
+                   page=${i})}"
+                 th:text="${i+1}">1</a>
             </span>
 
+            <!-- 다음 -->
             <a th:if="${surveys.hasNext()}"
                th:href="@{/admin/surveys/group(
-                     ageGroup=${ageGroup},
-                     category=${category},
-                     page=${surveys.number+1})}"
+                       ageGroup=${ageGroup},
+                       category=${category},
+                       targetGroup=${targetGroup},
+                       page=${surveys.number+1})}"
                class="px-3 py-1 bg-gray-200 rounded">다음</a>
         </div>
     </div>

--- a/src/main/resources/templates/admin/surveys/setList.html
+++ b/src/main/resources/templates/admin/surveys/setList.html
@@ -55,6 +55,17 @@
             </option>
         </select>
 
+        <select th:field="*{targetGroup}"
+                class="border rounded px-2 py-1">
+            <option th:value="${T(com.example.demo.enums.TargetGroup).ALL.name()}"
+                    th:text="'전체 대상'">
+            </option>
+            <option th:each="tg : ${targetOptions}"
+                    th:value="${tg.name()}"
+                    th:text="${tg.displayName}">
+            </option>
+        </select>
+
         <!-- 타입 필터 (변경 없음) -->
         <select th:field="*{type}" class="border rounded px-2 py-1">
             <option value="all">전체 종류</option>

--- a/src/main/resources/templates/community/allPostsList.html
+++ b/src/main/resources/templates/community/allPostsList.html
@@ -65,12 +65,19 @@
                     <td class="px-4 py-3 text-gray-800"
                         th:text="${#temporals.format(b.createdAt,'yyyy.MM.dd')}"></td>
                 </tr>
+                <!-- 데이터가 없을 때 -->
+                <tr th:if="${#lists.isEmpty(boards)}">
+                    <td colspan="6" class="px-4 py-6 text-center text-gray-500">
+                        검색 결과가 없습니다.
+                    </td>
+                </tr>
                 </tbody>
             </table>
         </div>
 
         <!-- 페이지네이션 -->
-        <nav class="mt-6 flex justify-center space-x-2">
+        <nav th:if="${pageData.totalElements > 0}"
+             class="mt-6 flex justify-center space-x-2">
             <span th:if="${pageData.hasPrevious()}">
                 <a th:href="@{/community/allPosts/list(page=${pageData.number-1},sort=${sort},keyword=${keyword})}"
                    class="px-3 py-1 bg-gray-200 text-[#E3A67A] rounded hover:bg-gray-300 transition">&lt; 이전</a>

--- a/src/main/resources/templates/community/announcementList.html
+++ b/src/main/resources/templates/community/announcementList.html
@@ -94,11 +94,18 @@
                     <td class="px-4 py-3 text-gray-800"
                         th:text="${#temporals.format(b.createdAt,'yyyy.MM.dd')}"/>
                 </tr>
+                <!-- 데이터가 없을 때 -->
+                <tr th:if="${#lists.isEmpty(boards)}">
+                    <td colspan="6" class="px-4 py-6 text-center text-gray-500">
+                        검색 결과가 없습니다.
+                    </td>
+                </tr>
                 </tbody>
             </table>
         </div>
 
-        <nav class="mt-6 flex justify-center space-x-2">
+        <nav th:if="${pageData.totalElements > 0}"
+             class="mt-6 flex justify-center space-x-2">
       <span th:if="${pageData.hasPrevious()}">
         <a th:href="@{/community/announcement/list(
             page=${pageData.number-1},

--- a/src/main/resources/templates/community/parentingList.html
+++ b/src/main/resources/templates/community/parentingList.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/default_layout}"
-      th:with="memberService=${@userService}">
+      th:with="userService=${@userService}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -96,15 +96,22 @@
                         th:text="${b.ageGroup.displayName}"/>
                     <td class="px-4 py-3 text-gray-800" th:text="${b.views}"/>
                     <td class="px-4 py-3 text-gray-800"
-                        th:text="${memberService.getMemberEntityById(b.usersId).nickname}"/>
+                        th:text="${userService.findNicknameOrDefault(b.usersId)}"/>
                     <td class="px-4 py-3 text-gray-800"
                         th:text="${#temporals.format(b.createdAt,'yyyy.MM.dd')}"/>
+                </tr>
+                <!-- 데이터가 없을 때 -->
+                <tr th:if="${#lists.isEmpty(boards)}">
+                    <td colspan="6" class="px-4 py-6 text-center text-gray-500">
+                        검색 결과가 없습니다.
+                    </td>
                 </tr>
                 </tbody>
             </table>
         </div>
 
-        <nav class="mt-6 flex justify-center space-x-2">
+        <nav th:if="${pageData.totalElements > 0}"
+             class="mt-6 flex justify-center space-x-2">
             <span th:if="${pageData.hasPrevious()}">
                 <a th:href="@{/community/parenting/list(
                     page=${pageData.number-1},

--- a/src/main/resources/templates/community/policyList.html
+++ b/src/main/resources/templates/community/policyList.html
@@ -105,11 +105,18 @@
                     <td class="px-4 py-3 text-gray-800"
                         th:text="${#temporals.format(b.createdAt,'yyyy.MM.dd')}"/>
                 </tr>
+                <!-- 데이터가 없을 때 -->
+                <tr th:if="${#lists.isEmpty(boards)}">
+                    <td colspan="6" class="px-4 py-6 text-center text-gray-500">
+                        검색 결과가 없습니다.
+                    </td>
+                </tr>
                 </tbody>
             </table>
         </div>
 
-        <nav class="mt-6 flex justify-center space-x-2">
+        <nav th:if="${pageData.totalElements > 0}"
+             class="mt-6 flex justify-center space-x-2">
       <span th:if="${pageData.hasPrevious()}">
         <a th:href="@{/community/policy/list(
             page=${pageData.number-1},

--- a/src/main/resources/templates/expert/main.html
+++ b/src/main/resources/templates/expert/main.html
@@ -9,9 +9,13 @@
             <section class="mb-10">
                 <h2 class="text-2xl font-bold mb-4">신규 상담</h2>
                 <div class="space-y-4">
-                    <div th:each="matching : ${matchingList}" class="block p-4 bg-white rounded-lg shadow hover:shadow-lg transition-shadow">
-                        <a th:href="@{/expert/matching/{id}(id=${matching.id})}" th:text="${matching.title}" class="text-lg font-medium text-gray-800">상담 제목</a>
-                        <p class="text-sm text-gray-500 mt-1" th:text="${#temporals.format(matching.createdAt, 'yyyy-MM-dd HH:mm')}">상담 신청 일자</p>
+                    <div th:each="matching : ${matchingList}">
+                    <a th:href="@{/expert/matching/{id}(id=${matching.id})}">
+                        <div class="block p-4 bg-white rounded-lg shadow hover:shadow-lg transition-shadow">
+                            <p th:href="@{/expert/matching/{id}(id=${matching.id})}" th:text="${matching.title}" class="text-lg font-medium text-gray-800">상담 제목</p>
+                            <p class="text-sm text-gray-500 mt-1" th:text="${#temporals.format(matching.createdAt, 'yyyy-MM-dd HH:mm')}">상담 신청 일자</p>
+                        </div>
+                    </a>
                     </div>
                 </div>
             </section>
@@ -20,15 +24,21 @@
                 <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
                     <div class="p-6 bg-white rounded-lg shadow text-center">
                         <p class="text-sm text-gray-500">총 상담 수</p>
-                        <p class="text-3xl font-bold text-gray-800 mt-2" th:text="${totalCount}">0</p>
+                        <a th:href="@{/expert/matching}"
+                           th:text="${totalCount}"
+                           class="text-3xl font-bold text-gray-800 mt-2">0</a>
                     </div>
                     <div class="p-6 bg-white rounded-lg shadow text-center">
                         <p class="text-sm text-gray-500">현재 진행 중인 상담</p>
-                        <p class="text-3xl font-bold text-gray-800 mt-2" th:text="${matchingCount}">0</p>
+                        <a th:href="@{/expert/matching?status=MATCHED}"
+                           th:text="${matchingCount}"
+                           class="text-3xl font-bold text-gray-800 mt-2">0</a>
                     </div>
                     <div class="p-6 bg-white rounded-lg shadow text-center">
                         <p class="text-sm text-gray-500">종료된 상담</p>
-                        <p class="text-3xl font-bold text-gray-800 mt-2" th:text="${endCount}">0</p>
+                        <a th:href="@{/expert/matching?status=RESPONDED}"
+                           th:text="${endCount}"
+                           class="text-3xl font-bold text-gray-800 mt-2">0</a>
                     </div>
                 </div>
             </section>

--- a/src/main/resources/templates/fragments/adminheader.html
+++ b/src/main/resources/templates/fragments/adminheader.html
@@ -79,6 +79,15 @@
                         </ul>
                     </li>
                     <a href="/admin/matching" class="block px-1 py-4 text-md hover:text-[#FEF9F3] whitespace-nowrap">전문가 매칭</a>
+
+                    <li class="relative group">
+                        <a href="/admin/community/parenting/list" class="block px-1 py-4 text-md hover:text-[#FEF9F3] whitespace-nowrap">커뮤니티 관리</a>
+                        <ul class="absolute top-full left-1/2 -translate-x-1/2 hidden group-hover:block hover:block bg-black bg-opacity-70 text-white shadow-lg mt-0.5 min-w-[180px] text-center z-50 py-2">
+                            <li><a href="/admin/community/parenting/list" class="block px-4 py-2 hover:text-gray-300">육아 커뮤니티 관리</a></li>
+                            <li><a href="/admin/community/policy/list" class="block px-4 py-2 hover:text-gray-300">정책 커뮤니티 관리</a></li>
+                        </ul>
+                    </li>
+
                     <a href="/admin/point" class="block px-1 py-4 text-md hover:text-[#FEF9F3] whitespace-nowrap">포인트 관리</a>
 
                     <li class="relative group">


### PR DESCRIPTION
### 관리자 커뮤니티 관리 페이지 구현
- 육아정보 커뮤니티 게시글 리스트 UI 설정
- 육아정보 커뮤니티 게시글 리스트 검색 결과 없을 시 안내 문구 추가

- 정책정보 커뮤니티 게시글 리스트 페이지
- 정책정보 커뮤니티 게시글 수정 기능
- 정책정보 커뮤니티 게시글 삭제 기능
- 정책정보 커뮤니티 댓글 수정 기능
- 정책정보 커뮤니티 댓글 삭제 기능

### 커뮤니티 페이지 수정
- 전체글 커뮤니티 검색 결과 없을 시 처리
- 공지사항 커뮤니티 검색 결과 없을 시 처리
- 육아정보 커뮤니티 검색 결과 없을 시 처리
- 정책정보 커뮤니티 검색 결과 없을 시 처리
- 육아정보 리스트 진입 시, 유저 못받아오는 오류 해결

### 관리자 헤더에 "커뮤니티 관리" 추가
- 서브 메뉴 육아 커뮤니티 관리, 정책 커뮤니티 관리
- 공지사항은 고객센터>공지사항에서 처리됨

### 전문가 상담 페이지 기능 추가
- 상담 홈, 상담 통계에서 총 상담 수, 현재 진행 중인 상담, 종료된 상담 각각 클릭 시, 해당 페이지로 이동

### 관리자 문진 세트 페이지 기능 추가
- 타겟그룹 필터링 추가

### 관리자 그룹 문진 페이지 기능 추가
- 타겟 그룹 필터링 추가
- 그룹 문진 생성 시, 타겟 그룹 선택 추가
- 그룹 문진 수정 시, 타겟 그룹 수정 추가